### PR TITLE
flake8 black compat

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,E701


### PR DESCRIPTION
- adopt the minimal configuration to make flake8 compatible with black https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#minimal-configuration