### PR TITLE
Create FloodModel and FloodModelParams for model API

### DIFF
--- a/usl_models/tests/model_test.py
+++ b/usl_models/tests/model_test.py
@@ -5,15 +5,7 @@ import tensorflow as tf
 from usl_models.flood_ml import constants
 from usl_models.flood_ml import data_utils
 from usl_models.flood_ml import model as flood_model
-
-_MODEL_PARAMS = {
-    "lstm_units": 32,
-    "lstm_kernels": 4,
-    "lstm_dropout": 0.2,
-    "lstm_recurrent_dropout": 0.2,
-    "m_rainfall": 3,
-    "n_flood_maps": 3,
-}
+from usl_models.flood_ml import model_params
 
 
 def fake_flood_input_batch(
@@ -21,8 +13,7 @@ def fake_flood_input_batch(
     height: int = constants.MAP_HEIGHT,
     width: int = constants.MAP_WIDTH,
     rainfall_duration: int = 24,
-    flood_maps: int = constants.N_FLOOD_MAPS,
-    include_flood_maps: bool = False,
+    include_flood_map: bool = False,
 ) -> dict[str, tf.Tensor]:
     """Creates a fake training batch for testing.
 
@@ -34,74 +25,127 @@ def fake_flood_input_batch(
         height: Optional height. Defaults to MAP_HEIGHT.
         width: Optional width. Defaults to MAP_WIDTH.
         rainfall_duration: Optional rainfall duration.
-        flood_maps: Optional number of flood maps. Defaults to N_FLOOD_MAPS.
-            Only used if include_flood_maps=True.
-        include_flood_maps: Whether or not to pass in flood maps as
-            spatiotemporal inputs.
+        include_flood_map: Whether or not to pass in a single flood map as the
+            spatiotemporal input.
 
     Returns:
         A dictionary of model inputs, with the following keys:
         - "geospatial": Required. A 4D tensor [batch, height, width, features].
         - "temporal": Required. A 2D tensor [batch, rainfall duration].
-        - "spatiotemporal": Optional. A 5D tensor of time series flood maps
-            [batch, time, height, width, 1].
+        - "spatiotemporal": Optional. A 4D tensor of time series flood maps
+            [batch, height, width, 1].
     """
     geospatial = tf.random.normal((batch_size, height, width, constants.GEO_FEATURES))
     temporal = tf.random.normal((batch_size, rainfall_duration))
 
     input = {"geospatial": geospatial, "temporal": temporal}
 
-    if include_flood_maps:
-        spatiotemporal = tf.random.normal((batch_size, flood_maps, height, width, 1))
+    if include_flood_map:
+        spatiotemporal = tf.random.normal((batch_size, height, width, 1))
         input["spatiotemporal"] = spatiotemporal
 
     return input
 
 
-def test_forward():
-    """Tests a single pass (prediction) of the model."""
+def test_convlstm_forward():
+    """Tests a single pass (prediction) of the model.
+
+    Expected input shapes:
+        st_input: [B, n, H, W, 1]
+        geo_input: [B, H, W, f]
+        temp_input: [B, n, m]
+
+    Expected output shape: [B, H, W, 1]
+    """
     batch_size = 4
     height, width = 100, 100
     flood_maps = 5
+    params = model_params.test_model_params
 
-    fake_input = fake_flood_input_batch(
-        batch_size,
-        height=height,
-        width=width,
-        flood_maps=flood_maps,
-        include_flood_maps=True,
-    )
-    geo_input = fake_input["geospatial"]
-    st_input = fake_input["spatiotemporal"]
-    temp_input = data_utils.temporal_window_view(
-        fake_input["temporal"], _MODEL_PARAMS["m_rainfall"]
-    )
+    st_input = tf.random.normal((batch_size, flood_maps, height, width, 1))
+    geo_input = tf.random.normal((batch_size, height, width, constants.GEO_FEATURES))
     # The forward function assumes temp_input has been clipped to the same
-    # time slice as the flood maps. We take the first <flood_maps> values.
-    temp_input = temp_input[:, :flood_maps, :]
+    # time slice as the flood maps, so we only create <flood_maps> values.
+    temp_input = tf.random.normal((batch_size, flood_maps))
+    temp_input = data_utils.temporal_window_view(temp_input, params.m_rainfall)
 
-    model = flood_model.FloodConvLSTM(_MODEL_PARAMS, 1, spatial_dims=(height, width))
+    model = flood_model.FloodConvLSTM(params, spatial_dims=(height, width))
     prediction = model.forward(st_input, geo_input, temp_input)
     assert prediction.shape == (batch_size, height, width, 1)
 
 
-def test_model_call():
-    """Tests the model call."""
+def test_convlstm_call():
+    """Tests the FloodConvLSTM model call.
+
+    Expected input shapes:
+        spatiotemporal: [B, H, W, 1)
+        geospatial: [B, H, W, f]
+        temporal: [B, T_max, m]
+
+    Expected output shape: [B, T, H, W]
+    """
     batch_size = 4
     height, width = 100, 100
-    rainfall_duration = 6
+    params = model_params.test_model_params
 
+    # The FloodConvLSTM model expects the data to have been preprocessed, such
+    # that it receives the full temporal inputs and a single flood map.
     fake_input = fake_flood_input_batch(
         batch_size,
         height=height,
         width=width,
-        rainfall_duration=rainfall_duration,
-        include_flood_maps=False,
+        include_flood_map=True,
     )
+    full_temp_input = data_utils.temporal_window_view(
+        fake_input["temporal"], params.m_rainfall
+    )
+    fake_input["temporal"] = full_temp_input
 
+    storm_duration = 12
     model = flood_model.FloodConvLSTM(
-        _MODEL_PARAMS, rainfall_duration, spatial_dims=(height, width)
+        params, n_predictions=storm_duration, spatial_dims=(height, width)
     )
-    flood_predictions, max_flood_prediction = model(fake_input)
-    assert flood_predictions.shape == (batch_size, rainfall_duration, height, width)
-    assert max_flood_prediction.shape == (batch_size, height, width)
+    prediction = model(fake_input)
+    assert prediction.shape == (batch_size, storm_duration, height, width)
+
+
+def test_train():
+    """Tests the model training.
+
+    Expected training inputs:
+        spatiotemporal: Optional[tf.Tensor[shape=(B, H, W, 1)]]
+        geospatial: tf.Tensor[shape=(B, H, W, f)]
+        temporal: tf.Tensor[shape=(B, T_max)]
+
+    Expected labels and outputs: tf.Tensor[shape=(B, T, H, W)]
+    """
+    batch_size = 16
+    height, width = 100, 100
+    rainfall_duration = 12
+    params = model_params.test_model_params
+
+    model = flood_model.FloodModel(params, spatial_dims=(height, width))
+
+    storm_1 = 4
+    fake_input_1 = fake_flood_input_batch(
+        batch_size,
+        height=height,
+        width=width,
+        rainfall_duration=rainfall_duration,
+    )
+    fake_labels_1 = tf.random.normal((batch_size, storm_1, height, width))
+    history_1 = model.train(fake_input_1, fake_labels_1, storm_1)
+    assert "loss" in history_1.history
+
+    # Also ensure model can continue training with varying storm durations.
+    # Note that this storm is shorter than the total rainfall data.
+    storm_2 = 8
+    fake_input_2 = fake_flood_input_batch(
+        batch_size // 2,
+        height=height,
+        width=width,
+        rainfall_duration=rainfall_duration,
+    )
+    fake_labels_2 = tf.random.normal((batch_size // 2, storm_2, height, width))
+    history_2 = model.train(fake_input_2, fake_labels_2, storm_2)
+    assert "loss" in history_2.history

--- a/usl_models/usl_models/flood_ml/model_params.py
+++ b/usl_models/usl_models/flood_ml/model_params.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from usl_models.flood_ml import constants
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, slots=True)
 class FloodModelParams:
     # General parameters.
     batch_size: int = 64

--- a/usl_models/usl_models/flood_ml/model_params.py
+++ b/usl_models/usl_models/flood_ml/model_params.py
@@ -1,0 +1,39 @@
+"""Flood model parameters."""
+
+from dataclasses import dataclass
+
+import tensorflow as tf
+
+from usl_models.flood_ml import constants
+
+
+@dataclass(kw_only=True)
+class FloodModelParams:
+    # General parameters.
+    batch_size: int = 64
+    m_rainfall: int = constants.M_RAINFALL
+    n_flood_maps: int = constants.N_FLOOD_MAPS
+
+    # Layer-specific parameters.
+    lstm_units: int = 128
+    lstm_kernel_size: int = 3
+    lstm_dropout: float = 0.2
+    lstm_recurrent_dropout: float = 0.2
+
+    # Keras parameters.
+    # While Keras models support (valid) string names, we choose to only accept
+    # the appropriate object instances for better type checking and to be
+    # explicit about hyperparameters (e.g., within the optimizer).
+    optimizer: tf.keras.Optimizer = tf.keras.optimizers.Adam(learning_rate=1e-3)
+    epochs: int = 10
+
+
+# Used for testing.
+test_model_params = FloodModelParams(
+    batch_size=4,
+    m_rainfall=3,
+    n_flood_maps=3,
+    lstm_units=32,
+    lstm_kernel_size=3,
+    epochs=1,
+)


### PR DESCRIPTION
Set up some initial components for the model pipeline, including a very naive training step.

- The newly-created `FloodModel` class will be how the user interfaces with the model for training, evaluation, and prediction, rather than using the Keras-based `FloodConvLSTM`.
- The `FloodModelParams` dataclass is a structured way to pass in configurable model parameters with better type checking and well-defined parameter names and default values.

Functional changes:
- We're no longer caching the `geo_cnn` output. This would have prevented the model from backpropagating correctly and updating the weights. We can consider introducing a caching mechanism for prediction at a later time.