### PR TITLE
Only Write Chunk Errors From Chunk Cloud Function

### DIFF
--- a/terraform/flood_config_functions.tf
+++ b/terraform/flood_config_functions.tf
@@ -1,0 +1,150 @@
+# Create buckets for storing raw files, file chunks and processed feature matrix chunks.
+resource "google_storage_bucket" "city_cat_config" {
+  name     = "climateiq-citycat-config"
+  location = "us-west1"
+}
+
+# Create a service account used by the function and Eventarc trigger
+resource "google_service_account" "city_cat_config" {
+  account_id   = "gcf-city-cat-sa"
+  display_name = "record-citycat-config cloud function service account"
+}
+
+resource "google_project_iam_member" "city_cat_config_invoking" {
+  project    = data.google_project.project.project_id
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${google_service_account.city_cat_config.email}"
+  depends_on = [google_project_iam_member.gcs_pubsub_publishing]
+}
+
+resource "google_project_iam_member" "city_cat_config_event_receiving" {
+  project    = data.google_project.project.project_id
+  role       = "roles/eventarc.eventReceiver"
+  member     = "serviceAccount:${google_service_account.city_cat_config.email}"
+  depends_on = [google_project_iam_member.invoking]
+}
+
+resource "google_project_iam_member" "city_cat_config_artifactregistry_reader" {
+  project    = data.google_project.project.project_id
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.city_cat_config.email}"
+  depends_on = [google_project_iam_member.event_receiving]
+}
+
+# Give read access to the citycat config bucket.
+resource "google_storage_bucket_iam_member" "city_cat_config_reader" {
+  bucket = google_storage_bucket.city_cat_config.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.city_cat_config.email}"
+}
+
+resource "google_storage_bucket_iam_member" "city_cat_features_writer" {
+  bucket = google_storage_bucket.features.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.city_cat_config.email}"
+}
+
+# Give write access to error reporter.
+resource "google_project_iam_member" "city_cat_config_error_writer" {
+  project = data.google_project.project.project_id
+  role    = "roles/errorreporting.writer"
+  member  = "serviceAccount:${google_service_account.city_cat_config.email}"
+}
+
+# Give write access to firestore.
+resource "google_project_iam_member" "city_cat_config_firestore_writer" {
+  project = data.google_project.project.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.city_cat_config.email}"
+}
+
+# Create a function triggered by writes to the citycat config bucket.
+resource "google_cloudfunctions2_function" "write_citycat_config" {
+  depends_on = [
+    google_project_iam_member.gcs_pubsub_publishing,
+  ]
+
+  name        = "write-citycat-config-data"
+  description = "Writes CityCAT config artifacts."
+  location    = lower(google_storage_bucket.city_cat_config.location) # The trigger must be in the same location as the bucket
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "write_flood_scenario_metadata_and_features"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.source.name
+        object = google_storage_bucket_object.source.name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = "256Mi"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.city_cat_config.email
+  }
+
+  event_trigger {
+    trigger_region        = lower(google_storage_bucket.city_cat_config.location) # The trigger must be in the same location as the bucket
+    event_type            = "google.cloud.storage.object.v1.finalized"
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = google_service_account.city_cat_config.email
+    event_filters {
+      attribute = "bucket"
+      value     = google_storage_bucket.city_cat_config.name
+    }
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      google_storage_bucket_object.source
+    ]
+  }
+}
+
+
+# Create a function triggered by deletes to the citycat config bucket.
+resource "google_cloudfunctions2_function" "delete_citycat_config" {
+  depends_on = [
+    google_project_iam_member.gcs_pubsub_publishing,
+  ]
+
+  name        = "delete-citycat-config-metadata"
+  description = "Deletes CityCAT config metadata from the metastore."
+  location    = lower(google_storage_bucket.city_cat_config.location) # The trigger must be in the same location as the bucket
+
+  build_config {
+    runtime     = "python311"
+    entry_point = "delete_flood_scenario_metadata"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.source.name
+        object = google_storage_bucket_object.source.name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = "256Mi"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.city_cat_config.email
+  }
+
+  event_trigger {
+    trigger_region        = lower(google_storage_bucket.city_cat_config.location) # The trigger must be in the same location as the bucket
+    event_type            = "google.cloud.storage.object.v1.deleted"
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = google_service_account.city_cat_config.email
+    event_filters {
+      attribute = "bucket"
+      value     = google_storage_bucket.city_cat_config.name
+    }
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      google_storage_bucket_object.source
+    ]
+  }
+}

--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -5,7 +5,7 @@ import io
 import pathlib
 import logging
 import tarfile
-from typing import BinaryIO, Callable, IO, Optional, Tuple
+from typing import BinaryIO, Callable, IO, Optional, TextIO, Tuple
 
 from google.cloud import error_reporting
 from google.cloud import firestore
@@ -15,12 +15,16 @@ import numpy
 from numpy.typing import NDArray
 import rasterio
 
+from usl_lib.readers import config_readers
 from usl_lib.readers import elevation_readers
 from usl_lib.storage import cloud_storage
 from usl_lib.storage import file_names
 from usl_lib.storage import metastore
 
-_MAX_RETRY_SECONDS = 20
+_MAX_RETRY_SECONDS = 60 * 2
+
+# The vector is long enough to express rainfall every five minutes for up to three days.
+_RAINFALL_VECTOR_LENGTH = (60 // 5) * 24 * 3
 
 
 @dataclasses.dataclass(slots=True)
@@ -116,7 +120,7 @@ def write_study_area_metadata(cloud_event: functions_framework.CloudEvent) -> No
     """Writes metadata for a study area on upload.
 
     This function is triggered when files containing raw geo data for an entire study
-    area are uploaded to GCP. It writes an entry to the metastore for the new study
+    area are uploaded to GCS. It writes an entry to the metastore for the new study
     area. It also calculates min & max values needed for feature scaling of the relevant
     files.
     """
@@ -149,6 +153,78 @@ def write_study_area_metadata(cloud_event: functions_framework.CloudEvent) -> No
 
 
 @functions_framework.cloud_event
+@_retry_and_report_errors()
+def write_flood_scenario_metadata_and_features(
+    cloud_event: functions_framework.CloudEvent,
+) -> None:
+    """Writes metadata and features for uploaded flood scenario config.
+
+    This function is triggered when files for rainfall configuration are uploaded to
+    GCS. It writes an entry to the metastore for the configuration and writes the
+    rainfall configuration as a feature vector into the GCS features bucket.
+    """
+    file_name = pathlib.PurePosixPath(cloud_event.data["name"])
+    # Distinguish between Rainfall_Data and CityCat_Config files, the latter of which we
+    # don't need to record.
+    if file_name.name.startswith("Rainfall_Data_"):
+        storage_client = storage.Client()
+        db = firestore.Client()
+
+        config_blob = storage_client.bucket(cloud_event.data["bucket"]).blob(
+            cloud_event.data["name"]
+        )
+        with config_blob.open("rt") as rain_fd:
+            as_vector = _rain_config_as_vector(rain_fd)
+
+        vector_blob = storage_client.bucket(cloud_storage.FEATURE_CHUNKS_BUCKET).blob(
+            f"rainfall/{file_name.with_suffix('.npy')}"
+        )
+        _write_as_npy(vector_blob, as_vector)
+
+        metastore.FloodScenarioConfig(
+            gcs_path=f"gs://{config_blob.bucket.name}/{config_blob.name}",
+            as_vector_gcs_path=f"gs://{vector_blob.bucket.name}/{vector_blob.name}",
+            # File names should be in the form <parent_config_name>/<file_name>
+            parent_config_name=file_name.parent.name,
+        ).set(db)
+
+
+def _rain_config_as_vector(rain_fd: TextIO) -> NDArray:
+    """Converts the rainfall config contents into a vector describing the rainfall.
+
+    Args:
+      rain_fd: The file containing the CityCAT rainfall configuration.
+
+    Returns:
+      The rainfall pattern as a numpy array.
+    """
+    entries = config_readers.read_rainfall_amounts(rain_fd)
+    return numpy.pad(
+        numpy.array(entries, dtype=numpy.float32),
+        (0, _RAINFALL_VECTOR_LENGTH - len(entries)),
+    )
+
+
+@functions_framework.cloud_event
+@_retry_and_report_errors()
+def delete_flood_scenario_metadata(cloud_event: functions_framework.CloudEvent) -> None:
+    """Delete metadata for uploaded flood scenario config.
+
+    This function is triggered when files for rainfall configuration are deleted from
+    GCS and likewise removes them from the metastore.
+    """
+    file_name = pathlib.PurePosixPath(cloud_event.data["name"])
+    # Distinguish between Rainfall_Data and CityCat_Config files, the latter of which we
+    # don't need to record.
+    if file_name.name.startswith("Rainfall_Data_"):
+        db = firestore.Client()
+
+        metastore.FloodScenarioConfig.delete(
+            db, f"gs://{cloud_event.data['bucket']}/{cloud_event.data['name']}"
+        )
+
+
+@functions_framework.cloud_event
 @_retry_and_report_errors(
     lambda cloud_event, exc: _write_chunk_metastore_error(
         cloud_event.data["name"], str(exc)
@@ -158,8 +234,8 @@ def build_feature_matrix(cloud_event: functions_framework.CloudEvent) -> None:
     """Builds a feature matrix when an archive of geo files is uploaded.
 
     This function is triggered when archive files containing geo data are uploaded to
-    GCP. It produces a feature matrix for the geo data and writes that feature matrix to
-    another GCP bucket for eventual use in model training and prediction.
+    GCS. It produces a feature matrix for the geo data and writes that feature matrix to
+    another GCS bucket for eventual use in model training and prediction.
     """
     storage_client = storage.Client()
     bucket = storage_client.bucket(cloud_event.data["bucket"])
@@ -176,14 +252,7 @@ def build_feature_matrix(cloud_event: functions_framework.CloudEvent) -> None:
         str(feature_file_name)
     )
 
-    # Write the feature matrix in .npy format to GCS.
-    matrix_file = io.BytesIO()
-    numpy.save(matrix_file, feature_matrix)
-    # Seek to the beginning so the file can be read.
-    matrix_file.flush()
-    matrix_file.seek(0)
-    feature_blob.upload_from_file(matrix_file)
-
+    _write_as_npy(feature_blob, feature_matrix)
     _write_metastore_entry(chunk_blob, feature_blob, metadata)
 
 
@@ -299,3 +368,18 @@ def _parse_chunk_path(chunk_path: str) -> Tuple[str, str]:
     """
     as_path = pathlib.PurePosixPath(chunk_path)
     return str(as_path.parent), as_path.stem
+
+
+def _write_as_npy(blob: storage.Blob, array: NDArray) -> None:
+    """Writes `array` into the GCS `blob` in the numpy binary array format.
+
+    Args:
+      blob: The blob to write the array into.
+      array: The array to upload.
+    """
+    npy_file = io.BytesIO()
+    numpy.save(npy_file, array)
+    # Seek to the beginning so the file can be read.
+    npy_file.flush()
+    npy_file.seek(0)
+    blob.upload_from_file(npy_file)

--- a/usl_pipeline/usl_lib/tests/readers/test_config_readers.py
+++ b/usl_pipeline/usl_lib/tests/readers/test_config_readers.py
@@ -1,0 +1,30 @@
+import io
+import textwrap
+
+import pytest
+
+from usl_lib.readers import config_readers
+
+
+def test_read_rainfall_amounts():
+    config = io.StringIO(
+        textwrap.dedent(
+            """\
+            * * *
+            * * * rainfall ***
+            * * *
+            13
+            * * *
+            0	0.0000000000
+            3600	0.0000019756
+            7200	0.0000019756
+            10800	0.0000019756
+            14400	0.0000039511
+            """
+        )
+    )
+
+    entries = config_readers.read_rainfall_amounts(config)
+    assert entries == pytest.approx(
+        [0, 0.0000019756, 0.0000019756, 0.0000019756, 0.0000039511]
+    )

--- a/usl_pipeline/usl_lib/tests/storage/test_metastore.py
+++ b/usl_pipeline/usl_lib/tests/storage/test_metastore.py
@@ -93,3 +93,39 @@ def test_study_area_chunk_merge():
             ),
         ]
     )
+
+
+def test_flood_scenario_config_set():
+    mock_db = mock.MagicMock()
+    metastore.FloodScenarioConfig(
+        gcs_path="a/b/c",
+        as_vector_gcs_path="d/e/f",
+        parent_config_name="parent",
+    ).set(mock_db)
+    mock_db.assert_has_calls(
+        [
+            mock.call.collection("city_cat_rainfall_configs"),
+            mock.call.collection().document("a%2Fb%2Fc"),
+            mock.call.collection()
+            .document()
+            .set(
+                {
+                    "parent_config_name:": "parent",
+                    "gcs_path": "a/b/c",
+                    "as_vector_gcs_path": "d/e/f",
+                },
+            ),
+        ]
+    )
+
+
+def test_flood_scenario_config_delete():
+    mock_db = mock.MagicMock()
+    metastore.FloodScenarioConfig.delete(mock_db, "a/b/c")
+    mock_db.assert_has_calls(
+        [
+            mock.call.collection("city_cat_rainfall_configs"),
+            mock.call.collection().document("a%2Fb%2Fc"),
+            mock.call.collection().document().delete(),
+        ]
+    )

--- a/usl_pipeline/usl_lib/usl_lib/readers/config_readers.py
+++ b/usl_pipeline/usl_lib/usl_lib/readers/config_readers.py
@@ -1,0 +1,23 @@
+import re
+from typing import Sequence, TextIO
+
+# Rainfall amount lines look like: "3600    0.0000019756"
+_RAINFALL_AMOUNT_RE = re.compile(r"\d+\s+(\d+\.\d+)")
+
+
+def read_rainfall_amounts(rain_fd: TextIO) -> Sequence[float]:
+    """Returns a list of rainfall amounts at each timestep in the CityCAT config.
+
+    Args:
+      rain_fd: The file containing the CityCAT rainfall configuration.
+
+    Returns:
+      The rainfall pattern as a sequence of rainfall amounts.
+    """
+    entries = []
+    for line in rain_fd:
+        rainfall_line = _RAINFALL_AMOUNT_RE.match(line)
+        if rainfall_line is None:
+            continue
+        entries.append(float(rainfall_line.group(1)))
+    return entries

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -1,11 +1,13 @@
 import dataclasses
 from typing import Optional
+import urllib.parse
 
 from google.cloud import firestore
 
 
 STUDY_AREAS = "study_areas"
 CHUNKS = "chunks"
+CITY_CAT_RAINFALL_CONFIG = "city_cat_rainfall_configs"
 
 
 @dataclasses.dataclass(slots=True)
@@ -169,3 +171,32 @@ def _update_study_area_min_max_elevation(
 
     if update:
         transaction.update(study_area_ref, update)
+
+
+@dataclasses.dataclass(slots=True)
+class FloodScenarioConfig:
+    """A configuration file describing rainfall patterns for a CityCAT simulation."""
+
+    gcs_path: str
+    as_vector_gcs_path: str
+    parent_config_name: str
+
+    def set(self, db: firestore.Client) -> None:
+        """Creates or updates an existing entry for a CityCAT configuration file."""
+        # Use the GCS path as the document ID. URL-escape the ID, as forward slashes
+        # aren't allowed in document IDs.
+        db.collection(CITY_CAT_RAINFALL_CONFIG).document(
+            urllib.parse.quote(self.gcs_path, safe=())
+        ).set(
+            {
+                "parent_config_name:": self.parent_config_name,
+                "gcs_path": self.gcs_path,
+                "as_vector_gcs_path": self.as_vector_gcs_path,
+            }
+        )
+
+    @staticmethod
+    def delete(db: firestore.Client, gcs_path: str) -> None:
+        db.collection(CITY_CAT_RAINFALL_CONFIG).document(
+            urllib.parse.quote(gcs_path, safe=())
+        ).delete()

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -197,6 +197,7 @@ class FloodScenarioConfig:
 
     @staticmethod
     def delete(db: firestore.Client, gcs_path: str) -> None:
+        """Deletes the CityCAT configuration entry for the given file."""
         db.collection(CITY_CAT_RAINFALL_CONFIG).document(
             urllib.parse.quote(gcs_path, safe=())
         ).delete()


### PR DESCRIPTION
- Only attempt to write feature chunk errors to the metastore from the feature chunk cloud function. Accomplish this by adding an argument to the `retry_and_report_errors` decorator for additional custom error handling and adding the additional metastore write when decorating the feature chunk cloud function.