### PR TITLE
Create Rainfall Config Features

### DIFF
--- a/terraform/flood_config_functions.tf
+++ b/terraform/flood_config_functions.tf
@@ -38,6 +38,12 @@ resource "google_storage_bucket_iam_member" "city_cat_config_reader" {
   member = "serviceAccount:${google_service_account.city_cat_config.email}"
 }
 
+resource "google_storage_bucket_iam_member" "city_cat_features_writer" {
+  bucket = google_storage_bucket.features.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.city_cat_config.email}"
+}
+
 # Give write access to error reporter.
 resource "google_project_iam_member" "city_cat_config_error_writer" {
   project = data.google_project.project.project_id
@@ -58,13 +64,13 @@ resource "google_cloudfunctions2_function" "write_citycat_config" {
     google_project_iam_member.gcs_pubsub_publishing,
   ]
 
-  name        = "write-citycat-config-metadata"
-  description = "Writes CityCAT config metadata to the metastore."
+  name        = "write-citycat-config-data"
+  description = "Writes CityCAT config artifacts."
   location    = lower(google_storage_bucket.city_cat_config.location) # The trigger must be in the same location as the bucket
 
   build_config {
     runtime     = "python311"
-    entry_point = "write_flood_scenario_metadata"
+    entry_point = "write_flood_scenario_metadata_and_features"
     source {
       storage_source {
         bucket = google_storage_bucket.source.name

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -1,9 +1,11 @@
 import datetime
 import io
 import tarfile
+import textwrap
 from unittest import mock
 
 from google.cloud import firestore
+from google.cloud import storage
 import functions_framework
 import numpy
 import rasterio
@@ -284,9 +286,36 @@ def test_write_study_area_metadata(mock_storage_client, mock_firestore_client):
 
 
 @mock.patch.object(main.firestore, "Client", autospec=True)
-def test_write_flood_scenario_metadata(mock_firestore_client):
+@mock.patch.object(main.storage, "Client", autospec=True)
+def test_write_flood_scenario_metadata(mock_storage_client, mock_firestore_client):
     """Ensure we sync config uploads to the metastore."""
-    main.write_flood_scenario_metadata(
+    config_blob = mock.Mock(spec=storage.Blob)
+    config_blob.name = "config_name/Rainfall_Data_1.txt"
+    config_blob.bucket.name = "bucket"
+    config_blob.open.return_value = io.StringIO(
+        textwrap.dedent(
+            """\
+            * * *
+            * * * rainfall ***
+            * * *
+            13
+            * * *
+            0	0.0000000000
+            3600	0.0000019756
+            7200	0.0000019756
+            10800	0.0000019756
+            14400	0.0000039511
+            """
+        )
+    )
+
+    vector_blob = mock.Mock(spec=storage.Blob)
+    vector_blob.name = "rainfall/config_name/Rainfall_Data_1.npy"
+    vector_blob.bucket.name = "climateiq-study-area-feature-chunks"
+
+    mock_storage_client().bucket("").blob.side_effect = [config_blob, vector_blob]
+
+    main.write_flood_scenario_metadata_and_features(
         functions_framework.CloudEvent(
             {"source": "test", "type": "event"},
             data={
@@ -295,6 +324,29 @@ def test_write_flood_scenario_metadata(mock_firestore_client):
                 "timeCreated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             },
         )
+    )
+
+    # Ensure we worked with the right GCP paths.
+    mock_storage_client.assert_has_calls(
+        [
+            mock.call().bucket("bucket"),
+            mock.call().bucket().blob("config_name/Rainfall_Data_1.txt"),
+            mock.call().bucket("climateiq-study-area-feature-chunks"),
+            mock.call().bucket().blob("rainfall/config_name/Rainfall_Data_1.npy"),
+        ]
+    )
+
+    config_blob.open.assert_called_once_with("rt")
+
+    # Ensure we attempted to upload a serialized array of the rainfall.
+    vector_blob.upload_from_file.assert_called_once_with(mock.ANY)
+    uploaded_array = numpy.load(vector_blob.upload_from_file.call_args[0][0])
+    numpy.testing.assert_array_almost_equal(
+        uploaded_array,
+        numpy.pad(
+            numpy.array([0.0, 0.0000019756, 0.0000019756, 0.0000019756, 0.0000039511]),
+            (0, main._RAINFALL_VECTOR_LENGTH - 5),
+        ),
     )
 
     # Ensure we wrote the firestore entry for the config.
@@ -312,6 +364,10 @@ def test_write_flood_scenario_metadata(mock_firestore_client):
                 {
                     "parent_config_name:": "config_name",
                     "gcs_path": "gs://bucket/config_name/Rainfall_Data_1.txt",
+                    "as_vector_gcs_path": (
+                        "gs://climateiq-study-area-feature-chunks/"
+                        "rainfall/config_name/Rainfall_Data_1.npy"
+                    ),
                 }
             ),
         ]
@@ -321,7 +377,7 @@ def test_write_flood_scenario_metadata(mock_firestore_client):
 @mock.patch.object(main.firestore, "Client", autospec=True)
 def test_write_flood_scenario_metadata_ignore_non_rainfall_files(mock_firestore_client):
     """Ensure we ignore non-rainfall config uploads."""
-    main.write_flood_scenario_metadata(
+    main.write_flood_scenario_metadata_and_features(
         functions_framework.CloudEvent(
             {"source": "test", "type": "event"},
             data={

--- a/usl_pipeline/usl_lib/tests/readers/test_config_readers.py
+++ b/usl_pipeline/usl_lib/tests/readers/test_config_readers.py
@@ -1,0 +1,30 @@
+import io
+import textwrap
+
+import pytest
+
+from usl_lib.readers import config_readers
+
+
+def test_read_rainfall_amounts():
+    config = io.StringIO(
+        textwrap.dedent(
+            """\
+            * * *
+            * * * rainfall ***
+            * * *
+            13
+            * * *
+            0	0.0000000000
+            3600	0.0000019756
+            7200	0.0000019756
+            10800	0.0000019756
+            14400	0.0000039511
+            """
+        )
+    )
+
+    entries = config_readers.read_rainfall_amounts(config)
+    assert entries == pytest.approx(
+        [0, 0.0000019756, 0.0000019756, 0.0000019756, 0.0000039511]
+    )

--- a/usl_pipeline/usl_lib/tests/storage/test_metastore.py
+++ b/usl_pipeline/usl_lib/tests/storage/test_metastore.py
@@ -99,6 +99,7 @@ def test_flood_scenario_config_set():
     mock_db = mock.MagicMock()
     metastore.FloodScenarioConfig(
         gcs_path="a/b/c",
+        as_vector_gcs_path="d/e/f",
         parent_config_name="parent",
     ).set(mock_db)
     mock_db.assert_has_calls(
@@ -111,6 +112,7 @@ def test_flood_scenario_config_set():
                 {
                     "parent_config_name:": "parent",
                     "gcs_path": "a/b/c",
+                    "as_vector_gcs_path": "d/e/f",
                 },
             ),
         ]

--- a/usl_pipeline/usl_lib/usl_lib/readers/config_readers.py
+++ b/usl_pipeline/usl_lib/usl_lib/readers/config_readers.py
@@ -1,0 +1,23 @@
+import re
+from typing import Sequence, TextIO
+
+# Rainfall amount lines look like: "3600    0.0000019756"
+_RAINFALL_AMOUNT_RE = re.compile(r"\d+\s+(\d+\.\d+)")
+
+
+def read_rainfall_amounts(rain_fd: TextIO) -> Sequence[float]:
+    """Returns a list of rainfall amounts at each timestep in the CityCAT config.
+
+    Args:
+      rain_fd: The file containing the CityCAT rainfall configuration.
+
+    Returns:
+      The rainfall pattern as a sequence of rainfall amounts.
+    """
+    entries = []
+    for line in rain_fd:
+        rainfall_line = _RAINFALL_AMOUNT_RE.match(line)
+        if rainfall_line is None:
+            continue
+        entries.append(float(rainfall_line.group(1)))
+    return entries

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -178,6 +178,7 @@ class FloodScenarioConfig:
     """A configuration file describing rainfall patterns for a CityCAT simulation."""
 
     gcs_path: str
+    as_vector_gcs_path: str
     parent_config_name: str
 
     def set(self, db: firestore.Client) -> None:
@@ -187,7 +188,11 @@ class FloodScenarioConfig:
         db.collection(CITY_CAT_RAINFALL_CONFIG).document(
             urllib.parse.quote(self.gcs_path, safe=())
         ).set(
-            {"parent_config_name:": self.parent_config_name, "gcs_path": self.gcs_path}
+            {
+                "parent_config_name:": self.parent_config_name,
+                "gcs_path": self.gcs_path,
+                "as_vector_gcs_path": self.as_vector_gcs_path,
+            }
         )
 
     @staticmethod


### PR DESCRIPTION
- Write the CityCAT rainfall configuration files as a numpy array into GCS as the config files are uploaded.