### PR TITLE
Write Un-Padded Number of Rainfall Entries to Metastore

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -174,7 +174,7 @@ def write_flood_scenario_metadata_and_features(
             cloud_event.data["name"]
         )
         with config_blob.open("rt") as rain_fd:
-            as_vector = _rain_config_as_vector(rain_fd)
+            as_vector, length = _rain_config_as_vector(rain_fd)
 
         vector_blob = storage_client.bucket(cloud_storage.FEATURE_CHUNKS_BUCKET).blob(
             f"rainfall/{file_name.with_suffix('.npy')}"
@@ -184,25 +184,31 @@ def write_flood_scenario_metadata_and_features(
         metastore.FloodScenarioConfig(
             gcs_path=f"gs://{config_blob.bucket.name}/{config_blob.name}",
             as_vector_gcs_path=f"gs://{vector_blob.bucket.name}/{vector_blob.name}",
+            num_rainfall_entries=length,
             # File names should be in the form <parent_config_name>/<file_name>
             parent_config_name=file_name.parent.name,
         ).set(db)
 
 
-def _rain_config_as_vector(rain_fd: TextIO) -> NDArray:
+def _rain_config_as_vector(rain_fd: TextIO) -> Tuple[NDArray, int]:
     """Converts the rainfall config contents into a vector describing the rainfall.
 
     Args:
       rain_fd: The file containing the CityCAT rainfall configuration.
 
     Returns:
-      The rainfall pattern as a numpy array.
+      A tuple of (rainfall, length) where `rainfall` contains
+      the rainfall pattern as a numpy array, padded to an agreed-upon
+      length, and `length` represent the un-padded number entries in
+      the array (i.e. the length the array would be if it was not
+      padded.)
+
     """
     entries = config_readers.read_rainfall_amounts(rain_fd)
     return numpy.pad(
         numpy.array(entries, dtype=numpy.float32),
         (0, _RAINFALL_VECTOR_LENGTH - len(entries)),
-    )
+    ), len(entries)
 
 
 @functions_framework.cloud_event

--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -205,6 +205,14 @@ def _rain_config_as_vector(rain_fd: TextIO) -> Tuple[NDArray, int]:
 
     """
     entries = config_readers.read_rainfall_amounts(rain_fd)
+
+    # The uploader should prevent configurations over this length.
+    if len(entries) > _RAINFALL_VECTOR_LENGTH:
+        raise ValueError(
+            f"Rainfall configuration has unexpected length {len(entries)}. "
+            f"Max allowed length is {_RAINFALL_VECTOR_LENGTH}."
+        )
+
     return numpy.pad(
         numpy.array(entries, dtype=numpy.float32),
         (0, _RAINFALL_VECTOR_LENGTH - len(entries)),

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -298,7 +298,7 @@ def test_write_flood_scenario_metadata(mock_storage_client, mock_firestore_clien
             * * *
             * * * rainfall ***
             * * *
-            13
+            5
             * * *
             0	0.0000000000
             3600	0.0000019756
@@ -364,6 +364,7 @@ def test_write_flood_scenario_metadata(mock_storage_client, mock_firestore_clien
                 {
                     "parent_config_name:": "config_name",
                     "gcs_path": "gs://bucket/config_name/Rainfall_Data_1.txt",
+                    "num_rainfall_entries": 5,
                     "as_vector_gcs_path": (
                         "gs://climateiq-study-area-feature-chunks/"
                         "rainfall/config_name/Rainfall_Data_1.npy"

--- a/usl_pipeline/usl_lib/tests/storage/test_metastore.py
+++ b/usl_pipeline/usl_lib/tests/storage/test_metastore.py
@@ -101,6 +101,7 @@ def test_flood_scenario_config_set():
         gcs_path="a/b/c",
         as_vector_gcs_path="d/e/f",
         parent_config_name="parent",
+        num_rainfall_entries=5,
     ).set(mock_db)
     mock_db.assert_has_calls(
         [
@@ -113,6 +114,7 @@ def test_flood_scenario_config_set():
                     "parent_config_name:": "parent",
                     "gcs_path": "a/b/c",
                     "as_vector_gcs_path": "d/e/f",
+                    "num_rainfall_entries": 5,
                 },
             ),
         ]

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -180,6 +180,7 @@ class FloodScenarioConfig:
     gcs_path: str
     as_vector_gcs_path: str
     parent_config_name: str
+    num_rainfall_entries: int
 
     def set(self, db: firestore.Client) -> None:
         """Creates or updates an existing entry for a CityCAT configuration file."""
@@ -192,6 +193,7 @@ class FloodScenarioConfig:
                 "parent_config_name:": self.parent_config_name,
                 "gcs_path": self.gcs_path,
                 "as_vector_gcs_path": self.as_vector_gcs_path,
+                "num_rainfall_entries": self.num_rainfall_entries,
             }
         )
 


### PR DESCRIPTION
- Record the un-padded number of timesteps in the rainfall vector. Model training needs access to this so it knows how many timesteps to train against in the auto-regressive loop.