### PR TITLE
Allow FloodModel to accept multiple storm durations

### DIFF
--- a/usl_models/tests/model_test.py
+++ b/usl_models/tests/model_test.py
@@ -1,19 +1,28 @@
 """Tests for Flood model."""
 
+import pytest
+
 import tensorflow as tf
 
-from usl_models.flood_ml import constants
 from usl_models.flood_ml import data_utils
 from usl_models.flood_ml import model as flood_model
 from usl_models.flood_ml import model_params
 
+# Use smaller feature spaces for testing, rather than the values provided in
+# constants.py.
+_TEST_GEO_FEATURES = 8
+_TEST_MAP_HEIGHT = 100
+_TEST_MAP_WIDTH = 100
+_TEST_MAX_RAINFALL = 36
+
 
 def fake_flood_input_batch(
     batch_size: int,
-    height: int = constants.MAP_HEIGHT,
-    width: int = constants.MAP_WIDTH,
-    rainfall_duration: int = 24,
+    height: int = _TEST_MAP_HEIGHT,
+    width: int = _TEST_MAP_WIDTH,
+    storm_duration: int = 2,
     include_flood_map: bool = False,
+    include_labels: bool = False,
 ) -> dict[str, tf.Tensor]:
     """Creates a fake training batch for testing.
 
@@ -22,27 +31,32 @@ def fake_flood_input_batch(
 
     Args:
         batch_size: Batch size.
-        height: Optional height. Defaults to MAP_HEIGHT.
-        width: Optional width. Defaults to MAP_WIDTH.
-        rainfall_duration: Optional rainfall duration.
+        height: Optional height.
+        width: Optional width.
+        storm_duration: Storm duration.
         include_flood_map: Whether or not to pass in a single flood map as the
             spatiotemporal input.
+        include_labels: Whether or not to include labels associated with the
+            inputs.
 
     Returns:
         A dictionary of model inputs, with the following keys:
         - "geospatial": Required. A 4D tensor [batch, height, width, features].
-        - "temporal": Required. A 2D tensor [batch, rainfall duration].
+        - "temporal": Required. A 2D tensor [batch, MAX_RAINFALL].
         - "spatiotemporal": Optional. A 4D tensor of time series flood maps
             [batch, height, width, 1].
     """
-    geospatial = tf.random.normal((batch_size, height, width, constants.GEO_FEATURES))
-    temporal = tf.random.normal((batch_size, rainfall_duration))
+    geospatial = tf.random.normal((batch_size, height, width, _TEST_GEO_FEATURES))
+    temporal = tf.random.normal((batch_size, _TEST_MAX_RAINFALL))
 
     input = {"geospatial": geospatial, "temporal": temporal}
 
     if include_flood_map:
         spatiotemporal = tf.random.normal((batch_size, height, width, 1))
         input["spatiotemporal"] = spatiotemporal
+
+    if include_labels:
+        input["labels"] = tf.random.normal((batch_size, storm_duration, height, width))
 
     return input
 
@@ -63,7 +77,7 @@ def test_convlstm_forward():
     params = model_params.test_model_params
 
     st_input = tf.random.normal((batch_size, flood_maps, height, width, 1))
-    geo_input = tf.random.normal((batch_size, height, width, constants.GEO_FEATURES))
+    geo_input = tf.random.normal((batch_size, height, width, _TEST_GEO_FEATURES))
     # The forward function assumes temp_input has been clipped to the same
     # time slice as the flood maps, so we only create <flood_maps> values.
     temp_input = tf.random.normal((batch_size, flood_maps))
@@ -86,6 +100,7 @@ def test_convlstm_call():
     """
     batch_size = 4
     height, width = 100, 100
+    storm_duration = 12
     params = model_params.test_model_params
 
     # The FloodConvLSTM model expects the data to have been preprocessed, such
@@ -101,7 +116,6 @@ def test_convlstm_call():
     )
     fake_input["temporal"] = full_temp_input
 
-    storm_duration = 12
     model = flood_model.FloodConvLSTM(
         params, n_predictions=storm_duration, spatial_dims=(height, width)
     )
@@ -121,7 +135,6 @@ def test_train():
     """
     batch_size = 16
     height, width = 100, 100
-    rainfall_duration = 12
     params = model_params.test_model_params
 
     model = flood_model.FloodModel(params, spatial_dims=(height, width))
@@ -131,21 +144,42 @@ def test_train():
         batch_size,
         height=height,
         width=width,
-        rainfall_duration=rainfall_duration,
+        storm_duration=storm_1,
+        include_labels=True,
     )
-    fake_labels_1 = tf.random.normal((batch_size, storm_1, height, width))
-    history_1 = model.train(fake_input_1, fake_labels_1, storm_1)
-    assert "loss" in history_1.history
+    fake_data_1 = flood_model.FloodModelData(storm_duration=storm_1, **fake_input_1)
 
-    # Also ensure model can continue training with varying storm durations.
-    # Note that this storm is shorter than the total rainfall data.
     storm_2 = 8
     fake_input_2 = fake_flood_input_batch(
         batch_size // 2,
         height=height,
         width=width,
-        rainfall_duration=rainfall_duration,
+        storm_duration=storm_2,
+        include_labels=True,
     )
-    fake_labels_2 = tf.random.normal((batch_size // 2, storm_2, height, width))
-    history_2 = model.train(fake_input_2, fake_labels_2, storm_2)
-    assert "loss" in history_2.history
+    fake_data_2 = flood_model.FloodModelData(storm_duration=storm_2, **fake_input_2)
+
+    history = model.train([fake_data_1, fake_data_2])
+    assert len(history) == 2
+
+
+def test_bad_labels():
+    """Tests validation of bad labels."""
+    batch_size = 8
+    height, width = 100, 100
+    params = model_params.test_model_params
+
+    model = flood_model.FloodModel(params, spatial_dims=(height, width))
+
+    storm_duration = 4
+    fake_input = fake_flood_input_batch(
+        batch_size,
+        height=height,
+        width=width,
+        storm_duration=8,  # labels do not match storm_duration
+        include_labels=True,
+    )
+    fake_data = flood_model.FloodModelData(storm_duration=storm_duration, **fake_input)
+
+    with pytest.raises(AssertionError):
+        model.train([fake_data])

--- a/usl_models/usl_models/flood_ml/constants.py
+++ b/usl_models/usl_models/flood_ml/constants.py
@@ -8,3 +8,4 @@ MAP_WIDTH = 1000
 # Temporal parameters. May be tuned.
 N_FLOOD_MAPS = 5
 M_RAINFALL = 6
+MAX_RAINFALL_DURATION = 864  # (60 / 5) * 24 * 3

--- a/usl_models/usl_models/flood_ml/data_utils.py
+++ b/usl_models/usl_models/flood_ml/data_utils.py
@@ -1,7 +1,36 @@
 """Data functions for Flood CNN model."""
 
+from dataclasses import dataclass
+from typing import Optional
+
 import numpy as np
 from numpy.lib import stride_tricks
+import tensorflow as tf
+
+
+@dataclass(kw_only=True, slots=True)
+class FloodModelData:
+    """Dataclass for flood model data.
+
+    Args:
+        storm_duration: Storm duration, as a unit of time steps (at 5-min
+            resolution). Synonymous with the number of flood predictions.
+        geospatial: Geospatial feature tensor. [H, W, f]
+        temporal: Temporal rainfall data. This can be 1D, in which case the
+            window view needs to be applied, or 2D, which is assumed to follow
+            the expected window view. [T_max(, m)]
+        spatiotemporal: Optional. A *single* flood map to specify the initial
+            flood conditions. [H, W, 1]
+        labels: Flood map labels, required during training. The first axis must
+            be the same as storm_duration.
+    """
+
+    storm_duration: int
+    geospatial: tf.Tensor
+    temporal: tf.Tensor
+    spatiotemporal: Optional[tf.Tensor] = None
+    # Labels must be included during training.
+    labels: Optional[tf.Tensor] = None
 
 
 def temporal_window_view(data: np.ndarray, window: int) -> np.ndarray:


### PR DESCRIPTION
The model will now accept a list of inputs, grouped by storm duration, and will fit on them incrementally.

Data are now expected to be structured as FloodModelData objects, which provides better validation.