### PR TITLE
Add Reader for CityCAT Simulation Files

### DIFF
--- a/usl_pipeline/study_area_uploader/study_area_uploader/transformers/elevation_transformers.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/transformers/elevation_transformers.py
@@ -37,18 +37,8 @@ def crop_geotiff_to_sub_area(
             input_file, header_only=True
         ).header
 
-    # This transformation is backward one mapping raster cells back to original
-    # coordinates (original_x = min_x + raster_x * step, y is similar).
-    bck_transform = rasterio.Affine(
-        header.cell_size,
-        0,
-        header.x_ll_corner,
-        0,
-        -header.cell_size,
-        header.y_ll_corner + header.row_count * header.cell_size,
-    )
     # The forward transformation maps X/Y coordinates to raster column/row.
-    fwd_transform = ~bck_transform
+    fwd_transform = header.forward_transform()
 
     left_col, lower_row = fwd_transform * (
         sub_area_bounding_box.min_x,

--- a/usl_pipeline/usl_lib/tests/readers/test_simulation_readers.py
+++ b/usl_pipeline/usl_lib/tests/readers/test_simulation_readers.py
@@ -1,0 +1,45 @@
+import io
+import textwrap
+
+import numpy
+
+from usl_lib.readers import simulation_readers
+from usl_lib.shared import geo_data
+
+
+def test_read_city_cat_result_as_raster():
+    result_file = io.StringIO(
+        textwrap.dedent(
+            """\
+            XCen YCen Depth Vx Vy T_300.000_sec
+            0 1 0.001 0.000 0.000
+            1 2 0.002 0.000 0.000
+            2 3 0.003 0.000 0.000
+            2 1 0.004 0.000 0.000
+            """
+        )
+    )
+    header = geo_data.ElevationHeader(
+        col_count=3,
+        row_count=4,
+        x_ll_corner=0,
+        y_ll_corner=0,
+        cell_size=1.0,
+        nodata_value=-9999.0,
+        crs=None,
+    )
+
+    raster = simulation_readers.read_city_cat_result_as_raster(result_file, header)
+    numpy.testing.assert_array_equal(
+        raster,
+        numpy.array(
+            [
+                [0, 0, 0],
+                [0, 0, 0.003],
+                [0, 0.002, 0],
+                [0.001, 0, 0.004],
+            ],
+            dtype=numpy.float32,
+        ),
+        strict=True,
+    )

--- a/usl_pipeline/usl_lib/usl_lib/readers/simulation_readers.py
+++ b/usl_pipeline/usl_lib/usl_lib/readers/simulation_readers.py
@@ -1,0 +1,45 @@
+"""Utilities for reading the outputs of physics-based simulations."""
+
+from typing import TextIO
+
+import numpy
+from numpy.typing import NDArray
+
+from usl_lib.shared import geo_data
+
+
+def read_city_cat_result_as_raster(
+    fd: TextIO, geo_header: geo_data.ElevationHeader
+) -> NDArray[numpy.float32]:
+    """Rasterizes an rsl output file produce by CityCAT as a numpy array.
+
+    Args:
+        fd: The rsl result with predicted flood depths file to read.
+        geo_header: A header describing the geography to rasterize the file into.
+
+    Returns:
+        The predicted flood depths rasterized as a numpy array.
+    """
+    sim_outputs = numpy.loadtxt(
+        fd,
+        skiprows=1,
+        dtype=numpy.float32,
+        usecols=(0, 1, 2),  # We just need the first 'XCen, YCen, Depth' columns.
+    )
+
+    # Convert the X/Y coordinates from the results to raster indices.
+    fwd_transform = geo_header.forward_transform()
+    indices = numpy.apply_along_axis(
+        lambda row: fwd_transform * row, 1, sim_outputs[:, :2]
+    )
+    # Round the indices into integers.
+    indices = numpy.rint(indices).astype(numpy.int64)
+
+    # The simulation will not predict values for every raster cell. Set empty to 0.
+    depth = numpy.zeros(
+        (geo_header.row_count, geo_header.col_count), dtype=numpy.float32
+    )
+    # Set the simulation outputs where we have them.
+    depth[indices[:, 1], indices[:, 0]] = sim_outputs[:, 2]
+
+    return depth

--- a/usl_pipeline/usl_lib/usl_lib/shared/geo_data.py
+++ b/usl_pipeline/usl_lib/usl_lib/shared/geo_data.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
-from rasterio import CRS
+import rasterio
 
 
 @dataclass
@@ -30,10 +30,25 @@ class ElevationHeader:
     y_ll_corner: float
     cell_size: float
     nodata_value: float
-    crs: Optional[CRS] = None
+    crs: Optional[rasterio.CRS] = None
+
+    def back_transform(self) -> rasterio.Affine:
+        """Creates an affine converting raster indices to X/Y coordinates."""
+        return rasterio.Affine(
+            self.cell_size,
+            0,
+            self.x_ll_corner,
+            0,
+            -self.cell_size,
+            self.y_ll_corner + self.row_count * self.cell_size,
+        )
+
+    def forward_transform(self) -> rasterio.Affine:
+        """Creates an affine converting X/Y coordinates to raster indices."""
+        return ~self.back_transform()
 
 
-@dataclass
+@dataclass(slots=True)
 class Elevation:
     header: ElevationHeader
     data: Optional[npt.NDArray[np.float64]] = None


### PR DESCRIPTION
- Add a reader for CityCAT rsl output files which returns their flood predictions as a raster.
- Factor out forward_transform & back_transform methods for building affines from elevation headers.