### PR TITLE
Extend build_feature_matrix_from_archive to handle heat modeling files

### DIFF
--- a/usl_pipeline/cloud_functions/requirements.txt
+++ b/usl_pipeline/cloud_functions/requirements.txt
@@ -29,10 +29,12 @@ grpc-google-iam-v1==0.13.0
 grpcio==1.62.1
 grpcio-status==1.62.1
 gunicorn==21.2.0
+h5netcdf==1.3.0
 idna==3.6
 itsdangerous==2.1.2
 Jinja2==3.1.3
 MarkupSafe==2.1.5
+netCDF4==1.6.5
 numpy==1.26.4
 packaging==24.0
 pandas==2.2.2
@@ -54,3 +56,4 @@ tzdata==2024.1
 urllib3==2.2.1
 watchdog==4.0.0
 Werkzeug==3.0.1
+xarray==2024.5.0


### PR DESCRIPTION
Add initial logic and unit test for modifying `build_feature_matrix` to handle wps files for AtmoML. Follow-up PRs will address:
- setting up the appropriate matrix transforms on the WPS variables that are in-scope for ML training
- writing to metastore