### PR TITLE
Exclusion logic for special soil classes that cannot be marked as green areas

### DIFF
--- a/usl_pipeline/study_area_uploader/study_area_uploader/main.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/main.py
@@ -40,6 +40,7 @@ def main() -> None:
             args.soil_type_mask_feature_property,
             pathlib.Path(temp_dir),
             study_area_bucket,
+            input_non_green_area_soil_classes=set(args.non_green_area_soil_classes),
         )
 
         if args.export_to_citycat:
@@ -166,6 +167,13 @@ def parse_args() -> argparse.Namespace:
         help="Indicates that more details of processing steps should be printed to the"
         + "console (INFO logging level instead of default ERROR one)",
         action=argparse.BooleanOptionalAction,
+    )
+    parser.add_argument(
+        "--non-green-area-soil-classes",
+        type=int,
+        default=[],
+        help="Optional list of soil classes that cannot be treated as green areas",
+        nargs="*",
     )
 
     return parser.parse_args()

--- a/usl_pipeline/study_area_uploader/study_area_uploader/main.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/main.py
@@ -176,4 +176,12 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    # Validation of CLI arguments
+    if args.soil_type_file and not args.non_green_area_soil_classes:
+        parser.error(
+            "--non_green_area_soil_classes required if --soil_type_file present"
+        )
+
+    return args

--- a/usl_pipeline/study_area_uploader/study_area_uploader/transformers/soil_classes_transformers.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/transformers/soil_classes_transformers.py
@@ -20,6 +20,15 @@ def transform_soil_classes_as_green_areas(
     raster where soil classes information is missing, the value is assigned from the
     nearest neighbor soil class polygon.
 
+    Here are formal steps of the algorithm:
+      - Exclude from soil class polygons all parts of regions that are outside green
+        areas, also filter out polygons with non-green soil classes, and report them as
+        polygons to the output;
+      - Classify soil classes for all raster cells from green areas that weren't covered
+        by any soil classes (including non-green ones) using nearest neighbor approach
+        looking for nearest non-green soil class polygons, and report them as 1-cell
+        polygons to the output in addition to the previous item.
+
     Args:
         elevation_header: The source of coordinate system and study area region info.
         green_areas_polygons: List of tuples with green area polygons.

--- a/usl_pipeline/study_area_uploader/study_area_uploader/transformers/study_area_transformers.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/transformers/study_area_transformers.py
@@ -97,7 +97,6 @@ def prepare_and_upload_study_area_files(
     work_dir: pathlib.Path,
     study_area_bucket: storage.Bucket,
     input_non_green_area_soil_classes: set[int] = set(),
-    output_non_green_area_soil_class: int = DEFAULT_NON_GREEN_AREA_SOIL_CLASS,
 ) -> PreparedInputData:
     """Prepares data needed to run pipeline for flood scenarios.
 
@@ -116,10 +115,8 @@ def prepare_and_upload_study_area_files(
         work_dir: A folder that can be used for transforming files.
         study_area_bucket: Target cloud storage bucket to export study area files to.
         input_non_green_area_soil_classes: Optional set of soil class values that will
-            be substituted by output_non_green_area_soil_class for unification of data
-            requirements.
-        output_non_green_area_soil_class: Optional special soil class that will be used
-            to indicate non-green area soil class polygons in the output.
+            be substituted by default non-green-area soil class for the unification of
+            subsequent pipeline processing.
 
     Returns:
         Prepared input data that can be exported to CityCat or be passed to chunker.
@@ -206,7 +203,7 @@ def prepare_and_upload_study_area_files(
                     _update_mask_if_needed(
                         polygon_mask,
                         input_non_green_area_soil_classes,
-                        output_non_green_area_soil_class,
+                        DEFAULT_NON_GREEN_AREA_SOIL_CLASS,
                     )
                     for polygon_mask in soil_classes_polygons
                 ]
@@ -234,7 +231,6 @@ def prepare_and_upload_citycat_input_files(
     citycat_bucket: storage.Bucket,
     elevation_geotiff_band: int = 1,
     default_no_data_value: float = -9999.0,
-    non_green_area_soil_classes: set[int] = {DEFAULT_NON_GREEN_AREA_SOIL_CLASS},
 ) -> None:
     """Prepares input files for CityCat simulation.
 
@@ -247,8 +243,6 @@ def prepare_and_upload_citycat_input_files(
         elevation_geotiff_band: Band index in elevation GeoTIFF file.
         default_no_data_value: Default value used in elevation data for cells where
             elevation is not defined.
-        non_green_area_soil_classes: Optional set of soil class values that should be
-            excluded from green areas.
     """
     # Export elevation data
     logging.info("Exporting elevation data to CityCat...")
@@ -310,7 +304,7 @@ def prepare_and_upload_citycat_input_files(
                     elevation_header,
                     green_areas_polygons,
                     input_data.soil_classes_polygons,
-                    non_green_area_soil_classes=non_green_area_soil_classes,
+                    non_green_area_soil_classes={DEFAULT_NON_GREEN_AREA_SOIL_CLASS},
                 )
             )
             export_mask_values = True

--- a/usl_pipeline/study_area_uploader/study_area_uploader/transformers/study_area_transformers.py
+++ b/usl_pipeline/study_area_uploader/study_area_uploader/transformers/study_area_transformers.py
@@ -17,7 +17,8 @@ from usl_lib.storage import file_names
 from usl_lib.transformers import polygon_transformers
 from usl_lib.writers import polygon_writers
 
-"""Default soil class value that is recognized a non-green area."""
+
+# Default soil class value that is recognized a non-green area.
 DEFAULT_NON_GREEN_AREA_SOIL_CLASS: int = -9999
 
 

--- a/usl_pipeline/study_area_uploader/tests/transformers/test_soil_classes_transformers.py
+++ b/usl_pipeline/study_area_uploader/tests/transformers/test_soil_classes_transformers.py
@@ -19,20 +19,24 @@ def test_transform_soil_classes_as_green_areas_happy_path():
     )
 
     green_areas_polygon_masks = [
-        (bbox_polygon(1, 1, 3, 2), 1),  # Raster: [0, 1, 1, 0], (row=0)
-        (bbox_polygon(2, 0, 4, 1), 1),  # Raster: [0, 0, 1, 1], (row=1)
+        (bbox_polygon(1, 1, 3, 2), 1),  # Raster mask: [0, 1, 1, 0], (row=0)
+        (bbox_polygon(2, 0, 4, 1), 1),  # Raster mask: [0, 0, 1, 1], (row=1)
     ]
     soil_classes_polygon_masks = [
-        (bbox_polygon(1, 1, 3, 3), 10),  # This will be used to fill in row:col=1:2
+        (bbox_polygon(1, 1, 2, 3), 10),  # This will be used to fill in row:col=1:2
         (bbox_polygon(4, 0, 5, 1), 11),  # This will be used to fill in row:col=1:3
+        (bbox_polygon(2, 1, 3, 2), 12),  # This will be ignored as non-green
     ]
 
     corrections = soil_classes_transformers.transform_soil_classes_as_green_areas(
-        header, green_areas_polygon_masks, soil_classes_polygon_masks
+        header,
+        green_areas_polygon_masks,
+        soil_classes_polygon_masks,
+        non_green_area_soil_classes={12},
     )
     assert len(corrections) == 3
     assert corrections[0][1] == 10
-    assert corrections[0][0].equals(bbox_polygon(1, 1, 3, 2))  # trimmed from (1,1,3,3)
+    assert corrections[0][0].equals(bbox_polygon(1, 1, 2, 2))  # trimmed from (1,1,2,3)
     assert corrections[1][1] == 10
     assert corrections[1][0].equals(bbox_polygon(2, 0, 3, 1))  # added from (1,1,3,3)
     assert corrections[2][1] == 11

--- a/usl_pipeline/study_area_uploader/tests/transformers/test_study_area_transformers.py
+++ b/usl_pipeline/study_area_uploader/tests/transformers/test_study_area_transformers.py
@@ -309,6 +309,109 @@ def test_prepare_and_upload_study_area_files_with_boundaries_green_areas_soil_cl
         )
 
 
+def test_prepare_and_upload_study_area_files_with_non_green_area_soil_class():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        work_dir = pathlib.Path(temp_dir)
+        elevation_input_file_path = work_dir / "input_elevation.tif"
+        prepare_elevation_data(
+            elevation_input_file_path,
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0],
+                [20.0, 21.0, 22.0, 23.0, 24.0],
+            ],
+        )
+        # Green areas
+        green_areas_input_file_path = work_dir / "green_areas.shp"
+        prepare_shape_file(
+            green_areas_input_file_path,
+            [(bbox_polygon(0, 0, 2, 2), 1)],
+        )
+        # Green areas
+        soil_classes_input_file_path = work_dir / "soil_classes.shp"
+        prepare_shape_file(
+            soil_classes_input_file_path,
+            [(bbox_polygon(0, 0, 1, 5), 99)],  # This polygon will be marked as -9999
+            soil_class_prop="soil_class",
+        )
+
+        # Mocks:
+        # Green areas storage file mocks
+        green_areas_cloud_storage_buffer = StringIO()
+        green_areas_cloud_storage_buffer.close = lambda: None  # Want to check content
+        green_areas_blob = mock.MagicMock(spec=storage.Blob)
+        green_areas_blob.open.return_value = green_areas_cloud_storage_buffer
+        # Soil classes storage file mocks
+        soil_classes_cloud_storage_buffer = StringIO()
+        soil_classes_cloud_storage_buffer.close = lambda: None  # Want to check content
+        soil_classes_blob = mock.MagicMock(spec=storage.Blob)
+        soil_classes_blob.open.return_value = soil_classes_cloud_storage_buffer
+        # Storage bucket
+        study_area_bucket = mock.MagicMock(spec=storage.Bucket)
+        elevation_blob = mock.MagicMock(spec=storage.Blob)
+        study_area_bucket.blob.side_effect = [
+            elevation_blob,
+            green_areas_blob,
+            soil_classes_blob,
+        ]
+
+        prepared_inputs = study_area_transformers.prepare_and_upload_study_area_files(
+            "TestArea1",
+            elevation_input_file_path,
+            None,
+            None,
+            green_areas_input_file_path,
+            soil_classes_input_file_path,
+            "soil_class",
+            work_dir,
+            study_area_bucket,
+            input_non_green_area_soil_classes={99},
+        )
+
+        with open(prepared_inputs.elevation_file_path, "rb") as input_file:
+            elevation = elevation_readers.read_from_geotiff(input_file)
+        assert elevation.header == geo_data.ElevationHeader(
+            col_count=5,
+            row_count=5,
+            x_ll_corner=0.0,
+            y_ll_corner=0.0,
+            cell_size=1.0,
+            nodata_value=0.0,
+            crs=rasterio.CRS({"init": "EPSG:32618"}),
+        )
+        testing.assert_array_equal(
+            elevation.data,
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0],
+                [15.0, 16.0, 17.0, 18.0, 19.0],
+                [20.0, 21.0, 22.0, 23.0, 24.0],
+            ],
+        )
+        assert len(prepared_inputs.green_areas_polygons) == 1
+        assert prepared_inputs.green_areas_polygons[0][0].equals(
+            bbox_polygon(0, 0, 2, 2)
+        )
+        assert len(prepared_inputs.soil_classes_polygons) == 1
+        assert prepared_inputs.soil_classes_polygons[0][0].equals(
+            bbox_polygon(0, 0, 1, 5)
+        )
+        assert prepared_inputs.soil_classes_polygons[0][1] == -9999  # default non-green
+        assert study_area_bucket.mock_calls == [
+            mock.call.blob("TestArea1/elevation.tif"),
+            mock.call.blob("TestArea1/green_areas.txt"),
+            mock.call.blob("TestArea1/soil_classes.txt"),
+        ]
+        assert elevation_blob.mock_calls == [
+            mock.call.upload_from_filename(str(prepared_inputs.elevation_file_path))
+        ]
+        assert green_areas_blob.mock_calls == [mock.call.open("w")]
+        assert soil_classes_blob.mock_calls == [mock.call.open("w")]
+
+
 def test_prepare_and_upload_citycat_input_files_no_boundaries_buildings_only():
     with tempfile.TemporaryDirectory() as temp_dir:
         work_dir = pathlib.Path(temp_dir)
@@ -469,6 +572,7 @@ def test_prepare_and_upload_citycat_input_files_with_boundaries_green_areas_and_
         ]
         green_areas_polygons = [(bbox_polygon(0, 0, 5, 3), 1)]
         soil_classes_polygons = [
+            (bbox_polygon(0, 0, 1, 5), -9999),  # Will be excluded from green areas
             (bbox_polygon(1, 0, 2.5, 5), 8),
             (bbox_polygon(2.5, 0, 4, 5), 9),
         ]
@@ -519,11 +623,10 @@ def test_prepare_and_upload_citycat_input_files_with_boundaries_green_areas_and_
             + "-1.0 -1.0 22.0 -1.0 -1.0\n"
         )
         assert green_areas_cloud_storage_buffer.getvalue() == (
-            "4\n"
+            "3\n"
             + "8 5 2.5 1.0 1.0 2.5 2.5 0.0 1.5 3.0 3.0 0.0\n"
             + "9 5 4.0 2.5 2.5 4.0 4.0 1.5 0.0 3.0 3.0 1.5\n"
             +
-            # the following 2 cells were added based on nearest neighbor approach
-            "8 5 0.0 1.0 1.0 0.0 0.0 2.0 2.0 3.0 3.0 2.0\n"
-            + "9 5 4.0 5.0 5.0 4.0 4.0 2.0 2.0 3.0 3.0 2.0\n"
+            # the following cell was added based on nearest neighbor approach
+            "9 5 4.0 5.0 5.0 4.0 4.0 2.0 2.0 3.0 3.0 2.0\n"
         )

--- a/usl_pipeline/usl_lib/usl_lib/transformers/polygon_transformers.py
+++ b/usl_pipeline/usl_lib/usl_lib/transformers/polygon_transformers.py
@@ -127,6 +127,7 @@ def crop_polygons_to_sub_area(
 def intersect(
     polygon_masks_to_process: Iterable[Tuple[geometry.Polygon, int]],
     multi_polygon_boundaries: geometry.MultiPolygon,
+    skip_logging: bool = False,
 ) -> Iterable[Tuple[geometry.Polygon, int]]:
     """Intersects polygons associated with integer masks with multi-polygon boundaries.
 
@@ -134,6 +135,7 @@ def intersect(
         polygon_masks_to_process: Input polygons associated with integer masks that
             intersection process should be applied to.
         multi_polygon_boundaries: Multi-polygon area to apply on the input polygons.
+        skip_logging: Optional indicator that logging should be skipped.
 
     Returns:
         Polygons associated with integer masks reduced to multi-polygon boundaries.
@@ -150,6 +152,7 @@ def intersect(
                 if not sub_polygon.is_empty:
                     yield sub_polygon, polygon_mask[1]
         processing_count = processing_count + 1
-        if processing_count % 1000 == 0:
+        if processing_count % 1000 == 0 and not skip_logging:
             logging.info("  - %s polygons are intersected so far", processing_count)
-    logging.info("  - %s polygons were intersected", processing_count)
+    if not skip_logging:
+        logging.info("  - %s polygons were intersected", processing_count)


### PR DESCRIPTION
This is a modification of the algorithm that reconstructs (or classify) green areas based on soil classes. It takes into account the requirement to exclude non-green area soil classes.

Before this change algorithm had the following steps:
1) Exclude from soil class polygons all parts of regions that are outside green areas, and report them to CityCat;
2) Classify soil classes for all raster cells from green areas that weren't covered by any soil classes using nearest neighbor approach looking for nearest soil class polygons, and report them as 1-cell polygons to CityCat in addition to item 1.

After the change:
1) Exclude from soil class polygons all parts of regions that are outside green areas, *also filter out polygons with non-green soil classes*, and report them as polygons to CityCat;
2) Classify soil classes for all raster cells from green areas that weren't covered by any soil classes *(including non-green ones)* using nearest neighbor approach looking for nearest *non-green* soil class polygons, and report them as 1-cell polygons to CityCat in addition to item 1.