### PR TITLE
Some Metastore Refactoring

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -184,8 +184,9 @@ def write_flood_scenario_metadata_and_features(
         _write_as_npy(vector_blob, as_vector)
 
         metastore.FloodScenarioConfig(
-            gcs_path=f"gs://{config_blob.bucket.name}/{config_blob.name}",
-            as_vector_gcs_path=f"gs://{vector_blob.bucket.name}/{vector_blob.name}",
+            name=config_blob.name,
+            gcs_uri=f"gs://{config_blob.bucket.name}/{config_blob.name}",
+            as_vector_gcs_uri=f"gs://{vector_blob.bucket.name}/{vector_blob.name}",
             rainfall_duration=length,
             # File names should be in the form <parent_config_name>/<file_name>
             parent_config_name=file_name.parent.name,
@@ -235,9 +236,7 @@ def delete_flood_scenario_metadata(cloud_event: functions_framework.CloudEvent) 
     if file_name.name.startswith("Rainfall_Data_"):
         db = firestore.Client()
 
-        metastore.FloodScenarioConfig.delete(
-            db, f"gs://{cloud_event.data['bucket']}/{cloud_event.data['name']}"
-        )
+        metastore.FloodScenarioConfig.delete(db, cloud_event.data["name"])
 
 
 @functions_framework.cloud_event

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -459,18 +459,16 @@ def test_write_flood_scenario_metadata(mock_storage_client, mock_firestore_clien
         [
             mock.call(),
             mock.call().collection("city_cat_rainfall_configs"),
-            mock.call()
-            .collection()
-            .document("gs%3A%2F%2Fbucket%2Fconfig_name%2FRainfall_Data_1.txt"),
+            mock.call().collection().document("config_name%2FRainfall_Data_1.txt"),
             mock.call()
             .collection()
             .document()
             .set(
                 {
-                    "parent_config_name:": "config_name",
-                    "gcs_path": "gs://bucket/config_name/Rainfall_Data_1.txt",
+                    "parent_config_name": "config_name",
+                    "gcs_uri": "gs://bucket/config_name/Rainfall_Data_1.txt",
                     "rainfall_duration": 5,
-                    "as_vector_gcs_path": (
+                    "as_vector_gcs_uri": (
                         "gs://climateiq-study-area-feature-chunks/"
                         "rainfall/config_name/Rainfall_Data_1.npy"
                     ),
@@ -556,9 +554,7 @@ def test_delete_flood_scenario_metadata(mock_firestore_client):
         [
             mock.call(),
             mock.call().collection("city_cat_rainfall_configs"),
-            mock.call()
-            .collection()
-            .document("gs%3A%2F%2Fbucket%2Fconfig_name%2FRainfall_Data_1.txt"),
+            mock.call().collection().document("config_name%2FRainfall_Data_1.txt"),
             mock.call().collection().document().delete(),
         ]
     )

--- a/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
+++ b/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
@@ -42,6 +42,7 @@ def test_create_get_study_area(firestore_db):
     )
     study_area.create(firestore_db)
     assert study_area == metastore.StudyArea.get(firestore_db, "test")
+    assert metastore.StudyArea.get_ref(firestore_db, "test").get().exists
 
 
 def test_update_min_max_elevation(firestore_db):
@@ -73,3 +74,32 @@ def test_update_min_max_elevation(firestore_db):
     study_area = metastore.StudyArea.get(firestore_db, "test")
     assert study_area.elevation_min == 1
     assert study_area.elevation_max == 30
+
+
+def test_flood_scenario_config_get_set_delete(firestore_db):
+    """Ensures we can create, retrieve and delete flood configs."""
+    flood = metastore.FloodScenarioConfig(
+        name="config/name.txt",
+        gcs_uri="gs://config-bucket/config/name.txt",
+        as_vector_gcs_uri="gs://feature-bucket/config/name.npy",
+        parent_config_name="config",
+        rainfall_duration=15,
+    )
+    flood.set(firestore_db)
+
+    assert flood == metastore.FloodScenarioConfig.get(firestore_db, "config/name.txt")
+    assert (
+        metastore.FloodScenarioConfig.get_ref(firestore_db, "config/name.txt")
+        .get()
+        .exists
+    )
+
+    metastore.FloodScenarioConfig.delete(firestore_db, "config/name.txt")
+
+    assert not (
+        metastore.FloodScenarioConfig.get_ref(firestore_db, "config/name.txt")
+        .get()
+        .exists
+    )
+    with pytest.raises(ValueError):
+        metastore.FloodScenarioConfig.get(firestore_db, "config/name.txt")


### PR DESCRIPTION
- Use 'uri' rather than 'path' for fields containing the full GCS URI
- Allow creating, deleting and retrieving `FloodScenarioConfig`s by ID rather than full URI.
- Add `get_ref` method for FloodScenarioConfig and StudyArea and refactor to use it internally.
- Add `as_header` method to StudyArea objects.