### PR TITLE
[WRF] Fix the order of netcdf spatial dimensions to always be: (lon, lat, ...)

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -338,6 +338,10 @@ def _process_wps_feature(feature: xarray.DataArray, var_config: dict) -> NDArray
     # Drop time axis
     feature = feature.isel(Time=0)
 
+    # Ensure order of dimension axes are: (west_east, south_north, <other spatial dims>)
+    # to stay consistent with rest of data pipeline
+    feature = feature.transpose("west_east", "south_north", ...)
+
     # FNL-derived var - extract to only first level
     if "num_metgrid_levels" in feature.dims:
         feature = feature.isel(num_metgrid_levels=0)


### PR DESCRIPTION
Variables in WRF/WPS will always be associated with some list of dimensions. The list of dimensions associated with each variable may vary depending on the nature of the variable. Typically, the dimensions could be `Time`, `south_north` (lon), `west_east` (lat), `some-z-dim`, `some-z-dim-1`, etc

Ordering of the dimensions follow a general convention of `Time`, `z`, `lon`, `lat` but may not always be consistent and the z dimension may also vary - see more: https://www.bic.mni.mcgill.ca/users/sean/Docs/netcdf/guide.txn_22.html.

We'll add an initial transform to set the axis order to always be `west_east` (lon), `south_north` (lat), `<other_spatial_dims>` to ensure consistency when processing the feature matrix (especially when extracting values from certain z dimensions, ex: `num_metgrid_levels`)