### PR TITLE
[WRF] Derive custom WPS variables: WSPD10, WDIR10

### DIFF
--- a/usl_pipeline/usl_lib/usl_lib/shared/wps_data.py
+++ b/usl_pipeline/usl_lib/usl_lib/shared/wps_data.py
@@ -21,6 +21,9 @@ class Unit(Enum):
     KELVIN = 5
     # Represented in decimal, range:0->1
     FRACTION = 6
+    METERSPERSEC = 7
+    # Measured clockwise from true north, range:0->359
+    DEGREES = 8
 
 
 ML_REQUIRED_VARS_REPO = dict(
@@ -78,6 +81,24 @@ ML_REQUIRED_VARS_REPO = dict(
             "unit": Unit.FRACTION,
             "scaling": {
                 "type": ScalingType.NONE,
+            },
+        },
+        # [Derived] 10meter Wind Speed
+        "WSPD10": {
+            "unit": Unit.METERSPERSEC,
+            "scaling": {
+                "type": ScalingType.GLOBAL,
+                "min": 0,
+                "max": 100,
+            },
+        },
+        # [Derived] 10meter Wind Direction
+        "WDIR10": {
+            "unit": Unit.DEGREES,
+            "scaling": {
+                "type": ScalingType.GLOBAL,
+                "min": 0,
+                "max": 359,
             },
         },
     }


### PR DESCRIPTION
Prior to performing feature engineering work on each feature DataArray, we'll first derive any custom, non-native WPS variables of interest.

For this initial case, we will compute 10m Wind Speed (`WSPD10`) and Wind Direction (`WDIR10`) from existing, standard variables `UU` and `VV` (wind vectors).