### PR TITLE
[WRF] Create new study area metastore entry when raw WPS file is uploaded

### DIFF
--- a/usl_pipeline/cloud_functions/requirements.txt
+++ b/usl_pipeline/cloud_functions/requirements.txt
@@ -50,6 +50,7 @@ python-dateutil==2.9.0.post0
 pytz==2024.1
 rasterio==1.3.9
 requests==2.31.0
+rioxarray==0.15.7
 rsa==4.9
 shapely==2.0.3
 six==1.16.0


### PR DESCRIPTION
When raw WPS files are first uploaded into `climateiq-atmospheric-simulation-input` GCS bucket, in-scope WPS file will be uploaded as a study area chunk. When this occurs, we will additionally write to metastore to create a new entry for this study area.

CRS value will be derived from a cartopy projection that utilize's wps file's map_projection value (lambert, meridian, etc). We will use the source_crs to populate the metastore entry