### PR TITLE
[WRF] Refactor build_feature_matrix to process un-tarred WRF input files

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -297,9 +297,9 @@ def delete_flood_scenario_metadata(cloud_event: functions_framework.CloudEvent) 
     )
 )
 def build_feature_matrix(cloud_event: functions_framework.CloudEvent) -> None:
-    """Builds a feature matrix when an archive of geo files is uploaded.
+    """Builds a feature matrix when an a set of geo files is uploaded.
 
-    This function is triggered when archive files containing geo data are uploaded to
+    This function is triggered when files containing geo data are uploaded to
     GCS. It produces a feature matrix for the geo data and writes that feature matrix to
     another GCS bucket for eventual use in model training and prediction.
     """
@@ -313,15 +313,24 @@ def build_feature_matrix(cloud_event: functions_framework.CloudEvent) -> None:
 def _build_feature_matrix(
     bucket_name: str, chunk_name: str, output_bucket: str
 ) -> None:
-    """Builds a feature matrix when an archive of geo files is uploaded."""
+    """Builds a feature matrix when a set of geo files is uploaded."""
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
     chunk_blob = bucket.blob(chunk_name)
 
-    with chunk_blob.open("rb") as archive:
-        feature_matrix, metadata = _build_feature_matrix_from_archive(archive)
-        if feature_matrix is None:
-            raise ValueError(f"Empty archive found in {chunk_blob}")
+    # TODO: Refactor to better handle both tar'ed + un-tarred chunks
+    with chunk_blob.open("rb") as chunk:
+        # Flood (CityCat)
+        if chunk_name.endswith(".tar"):
+            feature_matrix, metadata = _build_feature_matrix_from_archive(chunk)
+
+            if feature_matrix is None:
+                raise ValueError(f"Empty archive found in {chunk_blob}")
+        # Heat (WRF) - treat one WPS outout file as one chunk
+        elif re.search(file_names.WPS_DOMAIN3_NC_REGEX, chunk_name):
+            feature_matrix, metadata = _build_wps_feature_matrix(chunk)
+        else:
+            raise ValueError(f"Unexpected file {chunk_name}")
 
     feature_file_name = pathlib.PurePosixPath(chunk_name).with_suffix(".npy")
     feature_blob = storage_client.bucket(output_bucket).blob(str(feature_file_name))
@@ -562,7 +571,6 @@ def _build_feature_matrix_from_archive(
 
             name = pathlib.PurePosixPath(member.name).name
             files_in_tar.append(name)
-            # TODO: Group logic branch by path (per hazard model)
             # Handle flood model input files (CityCat)
             if name == file_names.ELEVATION_TIF:
                 elevation, metadata = _read_elevation_features(fd)
@@ -574,11 +582,9 @@ def _build_feature_matrix_from_archive(
                 green_areas = _read_polygons_from_byte_stream(fd)
             elif name == file_names.SOIL_CLASSES_TXT:
                 soil_classes = _read_polygons_from_byte_stream(fd)
-            # Handle heat model input files (WPS)
-            # TODO: Refactor to also handle un-tarred files
+            # Handle heat model input files (WPS) (if tarred)
             elif re.search(file_names.WPS_DOMAIN3_NC_REGEX, name):
                 return _build_wps_feature_matrix(fd)
-            # TODO: handle additional archive members.
             else:
                 logging.warning(f"Unexpected member name: {name}")
 
@@ -605,7 +611,7 @@ def _build_feature_matrix_from_archive(
 def _build_wps_feature_matrix(fd: IO[bytes]) -> Tuple[NDArray, FeatureMetadata]:
     # Ignore type checker error - BytesIO inherits from expected type BufferedIOBase
     # https://shorturl.at/lk4om
-    with xarray.open_dataset(fd) as ds:  # type: ignore
+    with xarray.open_dataset(fd, engine="h5netcdf") as ds:  # type: ignore
         # Assign Time coordinates so datetime is associated with each data array
         ds = ds.assign_coords(Time=ds.Times)
         # Derive non-native variables and assign to dataset

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -215,24 +215,16 @@ def test_build_feature_matrix_wrf(mock_storage_client, mock_firestore_client, _)
     memfile = ncfile.close()
     ncfile_bytes = memfile.tobytes()
 
-    # Place the ncfile bytes into an archive.
-    archive = io.BytesIO()
-    with tarfile.open(fileobj=archive, mode="w") as tar:
-        nc = tarfile.TarInfo("met_em.d03_test.nc")
-        nc.size = len(ncfile_bytes)
-        tar.addfile(nc, io.BytesIO(ncfile_bytes))
-    # Seek to the beginning so the file can be read.
-    archive.seek(0)
-
-    # Create a mock blob for the archive which will return the above netcdf when opened.
+    # Create a mock blob for the input file which will return the above netcdf when
+    # opened.
     mock_archive_blob = mock.MagicMock()
-    mock_archive_blob.name = "study_area/name.tar"
+    mock_archive_blob.name = "study_area/met_em.d03_test.nc"
     mock_archive_blob.bucket.name = "bucket"
-    mock_archive_blob.open.return_value = archive
+    mock_archive_blob.open.return_value = io.BytesIO(ncfile_bytes)
 
     # Create a mock blob for feature matrix we will upload.
     mock_feature_blob = mock.MagicMock()
-    mock_feature_blob.name = "study_area/name.npy"
+    mock_feature_blob.name = "study_area/met_em.d03_test.npy"
     mock_feature_blob.bucket.name = "climateiq-study-area-feature-chunks"
 
     # Return the mock blobs.
@@ -247,7 +239,7 @@ def test_build_feature_matrix_wrf(mock_storage_client, mock_firestore_client, _)
             {"source": "test", "type": "event"},
             data={
                 "bucket": "bucket",
-                "name": "study_area/name.tar",
+                "name": "study_area/met_em.d03_test.nc",
                 "timeCreated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             },
         )
@@ -257,9 +249,9 @@ def test_build_feature_matrix_wrf(mock_storage_client, mock_firestore_client, _)
     mock_storage_client.assert_has_calls(
         [
             mock.call().bucket("bucket"),
-            mock.call().bucket().blob("study_area/name.tar"),
+            mock.call().bucket().blob("study_area/met_em.d03_test.nc"),
             mock.call().bucket("climateiq-study-area-feature-chunks"),
-            mock.call().bucket().blob("study_area/name.npy"),
+            mock.call().bucket().blob("study_area/met_em.d03_test.npy"),
         ]
     )
 


### PR DESCRIPTION
Since we are treating one WPS file as one study area chunk, there is no need at this point to package this file into an archive for processing. Instead, we will load one WPS file (un-tarred) as a chunk and trigger `build_feature_matrix()` to process the netcdf file.