### PR TITLE
Mark Train / Test Split for Study Area

### DIFF
--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -165,9 +165,27 @@ def test_build_feature_matrix_flood(mock_storage_client, mock_firestore_client, 
         mock_firestore_client().collection().document(),
         {"elevation_min": 2, "elevation_max": 6},
     )
-    mock_firestore_client().collection().document().update.assert_called_once_with(
-        {"chunk_size": 2, "chunk_x_count": 5, "chunk_y_count": 10}
-    ),
+
+    # Ensure we called update with the correct dictionary.
+    update_args = (
+        mock_firestore_client().collection().document().update.call_args.args[0]
+    )
+
+    assert update_args.keys() == {
+        "chunk_size",
+        "chunk_x_count",
+        "chunk_y_count",
+        "train_indices",
+        "test_indices",
+    }
+    assert update_args["chunk_size"] == 2
+    assert update_args["chunk_x_count"] == 5
+    assert update_args["chunk_y_count"] == 10
+
+    # 40 / 50 chunks for training
+    assert len(update_args["train_indices"]) == 40
+    # 10 / 50 chunks for training
+    assert len(update_args["test_indices"]) == 10
 
 
 def test_build_feature_matrix_from_archive_empty_polygons():

--- a/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
+++ b/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
@@ -218,3 +218,42 @@ def test_get_simulation_bad_name_raises_error(firestore_db):
         metastore.Simulation.get(
             firestore_db, "missing-study-area", "missing-config/name.txt"
         )
+
+
+def test_update_chunk_info(firestore_db):
+    metastore.StudyArea(
+        name="study-area",
+        col_count=10,
+        row_count=4,
+        x_ll_corner=3,
+        y_ll_corner=4,
+        cell_size=5,
+        crs="crs",
+    ).create(firestore_db)
+
+    metastore.StudyArea.update_chunk_info(firestore_db, "study-area", 2, seed=2)
+    assert metastore.StudyArea.get(firestore_db, "study-area") == metastore.StudyArea(
+        name="study-area",
+        col_count=10,
+        row_count=4,
+        x_ll_corner=3,
+        y_ll_corner=4,
+        cell_size=5,
+        crs="crs",
+        chunk_x_count=5,  # 10 / 2
+        chunk_y_count=2,  # 4 / 2
+        chunks_size=2,
+        #  8 / 10 chunks for training.
+        train_indices=[
+            {"x_index": 0, "y_index": 0},
+            {"x_index": 0, "y_index": 1},
+            {"x_index": 1, "y_index": 0},
+            {"x_index": 1, "y_index": 1},
+            {"x_index": 2, "y_index": 0},
+            {"x_index": 3, "y_index": 0},
+            {"x_index": 3, "y_index": 1},
+            {"x_index": 4, "y_index": 0},
+        ],
+        #  2 / 10 chunks for test.
+        test_indices=[{"x_index": 2, "y_index": 1}, {"x_index": 4, "y_index": 1}],
+    )


### PR DESCRIPTION
- For a study area, indicate which 20% of its chunks should be considered the test set and which 80% should be considered the training set.

@tatianawu @prashantkul 
Here's what I was thinking for the test / train split in the metastore. The study area has a list of `{'x_index': x, 'y_index': y}` pairs for the train & test set. So you can look them up, then select the chunks with those indices within the study area you're interested in working with. Does this look all right to y'all?