### PR TITLE
Add early stopping support to FloodML

### DIFF
--- a/usl_models/tests/model_test.py
+++ b/usl_models/tests/model_test.py
@@ -194,11 +194,10 @@ def test_early_stopping():
     validation loss stops improving before training is complete. Enabling early stopping
     with a patience of 1 epoch means that the model should stop training as soon as the
     validaton loss goes up.
-
-    Note that this test is nondeterministic and possibly flaky. But with a large enough
-    number of epochs, this test is expected to pass with high likelihood. Empirically,
-    the model usually stops after 3-4 epochs.
     """
+    # To ensure determinism, we set a random seed so the model is reproducible.
+    tf.keras.utils.set_random_seed(1)
+
     batch_size = 16
     height, width = 100, 100
     # Set a large number of epochs to increase the odds of triggering early stopping.

--- a/usl_models/usl_models/flood_ml/model_params.py
+++ b/usl_models/usl_models/flood_ml/model_params.py
@@ -21,10 +21,9 @@ class FloodModelParams:
     lstm_recurrent_dropout: float = 0.2
 
     # Keras parameters.
-    # While Keras models support (valid) string names, we choose to only accept
-    # the appropriate object instances for better type checking and to be
-    # explicit about hyperparameters (e.g., within the optimizer).
-    optimizer: tf.keras.Optimizer = tf.keras.optimizers.Adam(learning_rate=1e-3)
+    # Keras models support both Optimizer objects and (valid) string names.
+    # It is the user's responsibility to pass in a valid optimizer value.
+    optimizer: tf.keras.Optimizer | str = "adam"
     epochs: int = 10
 
 


### PR DESCRIPTION
Added optional early stopping to the FloodML model.

Also fixed a bug in the FloodModelParams dataclass. The default optimizer is being used across all instances of the dataclass that don't specify a different value. Because this is currently a keras.Optimizer object, that same object is getting passed to possibly multiple models, which will throw an error. Changed this to a string, which is also a valid optimizer value. As with all other model parameters, we leave it to the user to supply reasonable values.