### PR TITLE
Fix for study area chunk metadata initialized too early due to error/retry

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -336,6 +336,13 @@ def _build_feature_matrix(
             chunk_metadata = metastore.StudyAreaSpatialChunk.get_if_exists(
                 firestore.Client(), study_area_name, chunk_name
             )
+            # Let's check if the chunk metadata object is present and has the state
+            # different from None (which means it's either FEATURE_MATRIX_PROCESSING
+            # meaning that unscaled feature matrix is stored and this CF succeeded, or
+            # it's FEATURE_MATRIX_READY and the downstream rescaling CF is also done).
+            # If metadata object is not present it means we're in the first execution
+            # attempt. None state means that we're in the retry and either this CF
+            # crashed during previous execution attempt or it finished with an error.
             if chunk_metadata is not None and chunk_metadata.state is not None:
                 logging.info(
                     "Flood feature matrix for chunk %s was already generated",

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -17,7 +17,7 @@ import xarray
 
 import main
 from usl_lib.shared import geo_data, wps_data
-from usl_lib.storage import file_names
+from usl_lib.storage import file_names, metastore
 
 
 def _add_to_tar(tar: tarfile.TarFile, file_name: str, content_bytes: bytes):
@@ -146,13 +146,14 @@ def test_build_feature_matrix_flood(mock_storage_client, mock_firestore_client, 
             mock.call().collection().document("study_area"),
             mock.call().collection().document().collection("chunks"),
             mock.call().collection().document().collection().document("chunk_1_2"),
-            mock.call()
-            .collection()
-            .document()
-            .collection()
-            .document()
-            .set(
+        ]
+    )
+    mock_db.collection().document().collection().document().set.assert_has_calls(
+        [
+            mock.call({"error": firestore.DELETE_FIELD}, merge=True),
+            mock.call(
                 {
+                    "state": metastore.StudyAreaChunkState.FEATURE_MATRIX_PROCESSING,
                     "raw_path": "gs://bucket/study_area/chunk_1_2.tar",
                     "needs_scaling": True,
                     "error": firestore.DELETE_FIELD,
@@ -171,6 +172,49 @@ def test_build_feature_matrix_flood(mock_storage_client, mock_firestore_client, 
     mock_db.collection().document().update.assert_called_once_with(
         {"chunk_size": 2, "chunk_x_count": 5, "chunk_y_count": 10}
     ),
+
+
+@mock.patch.object(main.error_reporting, "Client", autospec=True)
+@mock.patch.object(main.firestore, "Client", autospec=True)
+@mock.patch.object(main.storage, "Client", autospec=True)
+def test_build_feature_matrix_flood_already_done_will_be_skipped(
+    mock_storage_client, mock_firestore_client, _
+):
+    mock_feature_blob = mock.MagicMock()
+    mock_storage_client().bucket("").blob.side_effect = [
+        mock.MagicMock(),  # Input blob whose archive content is never used
+        mock_feature_blob,
+    ]
+    mock_storage_client.reset_mock()
+
+    mock_db = mock_firestore_client()
+
+    # The following statement means that the chunk was already processed before, and we
+    # don't need to process it again this time.
+    chunk_ref_mock = mock_db.collection().document().collection().document().get()
+    chunk_ref_mock.exists = True
+    chunk_ref_mock.to_dict.return_value = {
+        "state": metastore.StudyAreaChunkState.FEATURE_MATRIX_PROCESSING
+    }
+
+    main.build_feature_matrix(
+        functions_framework.CloudEvent(
+            {"source": "test", "type": "event"},
+            data={
+                "bucket": "bucket",
+                "name": "study_area/chunk_1_2.tar",
+                "timeCreated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            },
+        )
+    )
+
+    # Ensure we didn't upload a serialized matrix of the tiff
+    mock_feature_blob.upload_from_file.assert_not_called()
+
+    # Ensure we didn't do firestore changes
+    mock_db.collection().document().collection().document().set.assert_not_called()
+    mock_db.transaction().update.assert_not_called()
+    mock_db.collection().document().update.assert_not_called()
 
 
 def test_build_feature_matrix_from_archive_empty_polygons():
@@ -1583,9 +1627,11 @@ def test_rescale_feature_matrices_trigger_file_processed(mock_firestore_client):
             .document()
             .update(
                 {
+                    "state": metastore.StudyAreaChunkState.FEATURE_MATRIX_READY,
                     "needs_scaling": False,
                     "feature_matrix_path": "gs://features/TestArea/"
                     + "scaled_chunk_0_0.npy",
+                    "error": firestore.DELETE_FIELD,
                 },
             ),
         ]

--- a/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
+++ b/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
@@ -253,6 +253,47 @@ def test_create_get_study_area_spatial_chunk(firestore_db):
     )
 
 
+def test_spacial_chunk_update(firestore_db):
+    """Ensures a study area spatial chunk can be updated."""
+    study_area = metastore.StudyArea(
+        name="study_area_name",
+        col_count=1,
+        row_count=2,
+        x_ll_corner=3,
+        y_ll_corner=4,
+        cell_size=5,
+        crs="crs",
+    )
+    study_area.create(firestore_db)
+
+    chunk = metastore.StudyAreaSpatialChunk(
+        id_="chunk_name",
+        state=metastore.StudyAreaChunkState.FEATURE_MATRIX_PROCESSING,
+        raw_path="gcs://raw_file.tar",
+        needs_scaling=True,
+        x_index=1,
+        y_index=2,
+        error="Old error",
+    )
+    chunk.merge(firestore_db, "study_area_name")
+
+    metastore.StudyAreaSpatialChunk.update_scaling_done(
+        firestore_db, "study_area_name", "chunk_name", "gcs://feature_file.npy"
+    )
+
+    assert metastore.StudyAreaSpatialChunk.get(
+        firestore_db, "study_area_name", "chunk_name"
+    ) == metastore.StudyAreaSpatialChunk(
+        id_="chunk_name",
+        state=metastore.StudyAreaChunkState.FEATURE_MATRIX_READY,
+        raw_path="gcs://raw_file.tar",
+        feature_matrix_path="gcs://feature_file.npy",
+        needs_scaling=False,
+        x_index=1,
+        y_index=2,
+    )
+
+
 def test_delete_all_study_area_chunks(firestore_db):
     """Ensures all study area chunks can be deleted for a given study area."""
     study_area = metastore.StudyArea(

--- a/usl_pipeline/usl_lib/tests/storage/test_metastore.py
+++ b/usl_pipeline/usl_lib/tests/storage/test_metastore.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from google.cloud import firestore
 import rasterio
 
 from usl_lib.shared import geo_data
@@ -191,7 +192,12 @@ def test_study_area_chunk_update_scaling_done():
             .collection()
             .document()
             .update(
-                {"needs_scaling": False, "feature_matrix_path": "c/d"},
+                {
+                    "state": metastore.StudyAreaChunkState.FEATURE_MATRIX_READY,
+                    "needs_scaling": False,
+                    "feature_matrix_path": "c/d",
+                    "error": firestore.DELETE_FIELD,
+                },
             ),
         ]
     )

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -193,6 +193,11 @@ class StudyArea:
         return as_dict
 
 
+class StudyAreaChunkState(enum.StrEnum):
+    FEATURE_MATRIX_PROCESSING = "feature-matrix-processing"
+    FEATURE_MATRIX_READY = "feature-matrix-ready"
+
+
 @dataclasses.dataclass(slots=True)
 class StudyAreaChunk:
     """A chunk of a data within a larger study area.
@@ -209,6 +214,7 @@ class StudyAreaChunk:
     """
 
     id_: str
+    state: Optional[StudyAreaChunkState] = None
     raw_path: Optional[str] = None
     feature_matrix_path: Optional[str] = None
     needs_scaling: Optional[bool] = None
@@ -288,7 +294,12 @@ class StudyAreaChunk:
             scaled_feature_matrix_path: New GCS path pointing to scaled feature matrix.
         """
         cls.get_ref(db, study_area_name, chunk_name).update(
-            {"needs_scaling": False, "feature_matrix_path": scaled_feature_matrix_path},
+            {
+                "state": StudyAreaChunkState.FEATURE_MATRIX_READY,
+                "needs_scaling": False,
+                "feature_matrix_path": scaled_feature_matrix_path,
+                "error": firestore.DELETE_FIELD,
+            },
         )
 
 


### PR DESCRIPTION
The root cause we're trying to solve in this PR is the following. Before this PR we had a logic avoiding retry for build_feature_matrix CF if the chunk metadata is already present. But if the error happens in this CF we do create chunk metadata object with just error field populated which now blocks retry (it does detect the presence of chunk metadata and stops but it shouldn't in case of previous error).