### PR TITLE
[WRF] Bug fixes for build_feature_matrix for wps

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -328,11 +328,10 @@ def _build_feature_matrix(
     feature_file_name = pathlib.PurePosixPath(chunk_path).with_suffix(".npy")
     feature_blob = storage_client.bucket(output_bucket).blob(str(feature_file_name))
 
-    # TODO: Refactor to better handle both tar'ed + un-tarred chunks
     with chunk_blob.open("rb") as chunk:
+        study_area_name, chunk_name = _parse_chunk_path(chunk_path)
         # Flood (CityCat)
         if chunk_path.endswith(".tar"):
-            study_area_name, chunk_name = _parse_chunk_path(chunk_path)
             chunk_metadata = metastore.StudyAreaSpatialChunk.get_if_exists(
                 firestore.Client(), study_area_name, chunk_name
             )
@@ -664,9 +663,10 @@ def _build_wps_feature_matrix(fd: IO[bytes]) -> Tuple[NDArray, FeatureMetadata]:
             features_components.append(feature)
 
         features_matrix = numpy.dstack(features_components)
+        snapshot_time = ds.Times.values[0].decode("utf-8")
 
     return features_matrix, FeatureMetadata(
-        time=datetime.datetime.fromisoformat(str(ds.Times.values[0]))
+        time=datetime.datetime.fromisoformat(snapshot_time)
     )
 
 

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -285,11 +285,13 @@ def test_build_feature_matrix_wrf(mock_storage_client, mock_firestore_client, _)
     # Create an in-memory netcdf file and grab its bytes
     ncfile = netCDF4.Dataset("met_em.d03_test.nc", mode="w", format="NETCDF4", memory=1)
     ncfile.createDimension("Time", 1)
+    # Create new dim to represent length of datetime str
+    ncfile.createDimension("DateStrLen", 19)
     ncfile.createDimension("west_east", 3)
     ncfile.createDimension("south_north", 3)
 
     # In WPS/WRF files, 'Times'->dimension and 'Time'->variable
-    time = ncfile.createVariable("Times", "str", ("Time",))
+    time = ncfile.createVariable("Times", "S1", ("Time", "DateStrLen"))
     lat = ncfile.createVariable("lat", "float32", ("south_north",))
     lon = ncfile.createVariable("lon", "float32", ("west_east",))
     # Create dataset entries for all variables in mock
@@ -300,7 +302,7 @@ def test_build_feature_matrix_wrf(mock_storage_client, mock_firestore_client, _)
         "NOT_REQUIRED_VAR", "float32", ("Time", "south_north", "west_east")
     )
 
-    time[0] = "2010-02-02_18:00:00"
+    time[0] = netCDF4.stringtochar(numpy.array(["2010-02-02_18:00:00"], dtype="S19"))
     lat[:] = [200, 200, 200]
     lon[:] = [300, 300, 300]
     ncfile.variables["GHT"][:] = netcdf_array1


### PR DESCRIPTION
* Update parsing for timestamp from netfdf when writing to metastore - needs to be decoded (similar to what is done for labels: https://github.com/UrbanSystemsLab/climateiq-cnn/pull/97)
* Fix chunk_path reference so it is accessible by wrf's sectino of the if/else statement