### PR TITLE
[WRF] Add missing `cartopy` package in requirements.txt

### DIFF
--- a/usl_pipeline/cloud_functions/requirements.txt
+++ b/usl_pipeline/cloud_functions/requirements.txt
@@ -2,6 +2,7 @@ affine==2.4.0
 attrs==23.2.0
 blinker==1.7.0
 cachetools==5.3.3
+cartopy==0.23.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7


### PR DESCRIPTION
Fixes bug when CF attempts to write to metastore and utilizes cartopy to extract CRS value