### PR TITLE
Add a validation split to label chunks

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -690,7 +690,7 @@ def _collapse_city_cat_output_chunks(
         gcs_uri=f"gs://{labels_bucket.name}/{label_path}",
         x_index=x_index,
         y_index=y_index,
-        in_test_set=metastore.SimulationLabelSpatialChunk.is_in_test_set(
+        dataset=metastore.SimulationLabelSpatialChunk.dataset_split(
             study_area, config_path, x_index, y_index
         ),
     ).set(db, study_area_name, config_path)

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -1482,7 +1482,7 @@ def test_collapse_city_cat_output_chunks(mock_firestore_client):
                     ),
                     "x_index": 0,
                     "y_index": 1,
-                    "in_test_set": False,
+                    "dataset": metastore.DatasetSplit.TRAIN,
                 }
             ),
         ]

--- a/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
+++ b/usl_pipeline/usl_lib/tests/integration/test_metastore_integration.py
@@ -146,7 +146,7 @@ def test_simulation_get_set_label_chunks(firestore_db):
         gcs_uri="gs://sim-chunks/study-area/config/name.txt/0_0.npy",
         x_index=0,
         y_index=0,
-        in_test_set=True,
+        dataset=metastore.DatasetSplit.TEST,
     )
     chunk_1.set(firestore_db, "study-area", "config/name.txt")
 
@@ -154,7 +154,7 @@ def test_simulation_get_set_label_chunks(firestore_db):
         gcs_uri="gs://sim-chunks/study-area/config/name.txt/0_1.npy",
         x_index=1,
         y_index=0,
-        in_test_set=False,
+        dataset=metastore.DatasetSplit.TRAIN,
     )
     chunk_2.set(firestore_db, "study-area", "config/name.txt")
 

--- a/usl_pipeline/usl_lib/tests/storage/test_metastore.py
+++ b/usl_pipeline/usl_lib/tests/storage/test_metastore.py
@@ -242,8 +242,8 @@ def test_flood_scenario_config_delete():
     )
 
 
-def test_simulation_label_chunk_is_in_test_set_produce_right_split() -> None:
-    """Ensure is_in_test_set produces a 20-80 split."""
+def test_simulation_label_chunk_dataset_split_produce_right_split() -> None:
+    """Ensure dataset_split produces a 60/20/20 split."""
     study_area = metastore.StudyArea(
         name="name",
         col_count=2,
@@ -257,45 +257,27 @@ def test_simulation_label_chunk_is_in_test_set_produce_right_split() -> None:
         chunk_y_count=5,
     )
 
-    # Calculate whether all chunks are in the test set.
-    chunks_in_test_set = [
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 0, 0
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 0, 1
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 0, 2
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 0, 3
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 0, 4
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 1, 0
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 1, 1
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 1, 2
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 1, 3
-        ),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(
-            study_area, "config", 1, 4
-        ),
+    # Calculate the number of chunks in each set.
+    chunks_dataset_split = [
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 2),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 3),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 4),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 1, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 1, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 1, 2),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 1, 3),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 1, 4),
     ]
-    # 2 / 10 of the chunks should be in the test set.
-    assert sum(chunks_in_test_set) == 2
+    # Chunks should be split 6 / 2 / 2 in train / val / test.
+    assert chunks_dataset_split.count(metastore.DatasetSplit.TRAIN) == 6
+    assert chunks_dataset_split.count(metastore.DatasetSplit.VAL) == 2
+    assert chunks_dataset_split.count(metastore.DatasetSplit.TEST) == 2
 
 
-def test_simulation_label_chunk_is_in_test_set_is_deterministic() -> None:
-    """Ensure is_in_test_set produces deterministic outputs."""
+def test_simulation_label_chunk_dataset_split_is_deterministic() -> None:
+    """Ensure dataset_split produces deterministic outputs."""
     study_area = metastore.StudyArea(
         name="name",
         col_count=2,
@@ -311,15 +293,15 @@ def test_simulation_label_chunk_is_in_test_set_is_deterministic() -> None:
 
     # Call the function with the same inputs several times.
     results = [
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "config", 0, 0)
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "config", 0, 0)
         for _ in range(10)
     ]
     # Ensure they're all the same.
     assert all(res == results[0] for res in results)
 
 
-def test_simulation_label_chunk_is_in_test_produces_different_splits() -> None:
-    """Ensure is_in_test_set produces distinct splits for distinct simulations."""
+def test_simulation_label_chunk_dataset_split_produces_different_splits() -> None:
+    """Ensure dataset_split produces distinct splits for distinct simulations."""
     study_area = metastore.StudyArea(
         name="name",
         col_count=2,
@@ -333,26 +315,26 @@ def test_simulation_label_chunk_is_in_test_produces_different_splits() -> None:
         chunk_y_count=5,
     )
 
-    chunks_in_test_set_for_config_1 = [
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 0, 0),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 0, 1),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 0, 2),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 1, 0),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 1, 1),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c1", 1, 2),
+    chunks_dataset_split_for_config_1 = [
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 0, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 0, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 0, 2),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 1, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 1, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c1", 1, 2),
     ]
 
-    chunks_in_test_set_for_config_2 = [
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 0, 0),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 0, 1),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 0, 2),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 1, 0),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 1, 1),
-        metastore.SimulationLabelSpatialChunk.is_in_test_set(study_area, "c2", 1, 2),
+    chunks_dataset_split_for_config_2 = [
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 0, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 0, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 0, 2),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 1, 0),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 1, 1),
+        metastore.SimulationLabelSpatialChunk.dataset_split(study_area, "c2", 1, 2),
     ]
 
     # Different simulation config names could potentially result in
     # the same set of chunks in the test set, but our use of
     # seeds ensures we will get the same sets for the same
     # configuration names, making this test reproducible.
-    assert chunks_in_test_set_for_config_1 != chunks_in_test_set_for_config_2
+    assert chunks_dataset_split_for_config_1 != chunks_dataset_split_for_config_2

--- a/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/metastore.py
@@ -544,6 +544,12 @@ class SimulationLabelChunk:
             yield cls(**chunk_ref.get().to_dict())
 
 
+class DatasetSplit(enum.StrEnum):
+    TRAIN = "train"
+    VAL = "val"
+    TEST = "test"
+
+
 @dataclasses.dataclass(slots=True)
 class SimulationLabelSpatialChunk(SimulationLabelChunk):
     """A sub-area chunk of a larger study area.
@@ -551,13 +557,12 @@ class SimulationLabelSpatialChunk(SimulationLabelChunk):
     Attributes:
         x_index: The x index of the chunk relative to other chunks in the simulation.
         y_index: The y index of the chunk relative to other chunks in the simulation.
-        in_test_set: Whether the label should be held out from model training as
-                     part of the test set.
+        dataset: Which data set the label belongs to: train, val, test.
     """
 
     x_index: int
     y_index: int
-    in_test_set: bool
+    dataset: DatasetSplit
 
     def set(self, db: firestore.Client, study_area_name: str, config_path: str) -> None:
         """Adds the label chunk to the given simulation."""
@@ -567,17 +572,17 @@ class SimulationLabelSpatialChunk(SimulationLabelChunk):
         ).document(id_).set(dataclasses.asdict(self))
 
     @staticmethod
-    def is_in_test_set(
+    def dataset_split(
         study_area: "StudyArea", config_name: str, x_index: int, y_index: int
-    ) -> bool:
-        """Determines if the chunk for the given indices is in the test set.
+    ) -> DatasetSplit:
+        """Determines whether the chunk is used for training, validation, or testing.
 
         Given x and y indices which uniquely identify a label chunk with a given study
         area for a given simulation configuation, determines if the label chunk should
-        be considered as part of the test or training set.
+        be considered as part of the training, validation, or test set.
         Returns a consistent set membership for the same study area, config and index
-        pairs while also guaranteeing the split for all chunks within the study area is
-        a 20% / 80% test / training split.
+        pairs while also guaranteeing a 60 train / 20 val / 20 test split for all chunks
+        within the study area.
 
         Args:
           study_area: The study area of the label chunk being considered.
@@ -586,7 +591,7 @@ class SimulationLabelSpatialChunk(SimulationLabelChunk):
           y_index: The y index of the chunk relative to other chunks in the simulation.
 
         Returns:
-          A boolean indicating if the chunk is part of the test set.
+          A DatasetSplit indicating which set the chunk belongs to: train, val, or test.
         """
         if study_area.chunk_x_count is None or study_area.chunk_y_count is None:
             raise ValueError(
@@ -604,14 +609,14 @@ class SimulationLabelSpatialChunk(SimulationLabelChunk):
         ]
 
         # Determine if the given x & y index should represent a member
-        # of the test or training set.  The test set should be 20% of
-        # the chunks.  We do this by building a random state, using
+        # of the train, val, or test set. This should be a 60/20/20 split
+        # on the chunks. We do this by building a random state, using
         # the study area name and simulation config name as a seed.
         # This means we will consistently generate the same set of
         # chunks as test and training set members for a given study
-        # area and simulation config.  This allows us to generate a
-        # consistent test and training set no matter how many times
-        # any individual processing function may run.
+        # area and simulation config.  This allows us to generate
+        # consistent sets no matter how many times any individual
+        # processing function may run.
         hasher = hashlib.new("sha1", usedforsecurity=False)
         hasher.update(study_area.name.encode())
         hasher.update(config_name.encode())
@@ -619,8 +624,13 @@ class SimulationLabelSpatialChunk(SimulationLabelChunk):
         rand_state = random.Random(seed)
         rand_state.shuffle(chunk_indices)
 
-        split = int(0.2 * len(chunk_indices))
-        return (x_index, y_index) in set(chunk_indices[:split])
+        train_split = int(0.6 * len(chunk_indices))
+        val_split = int(0.8 * len(chunk_indices))
+        if (x_index, y_index) in set(chunk_indices[:train_split]):
+            return DatasetSplit.TRAIN
+        if (x_index, y_index) in set(chunk_indices[train_split:val_split]):
+            return DatasetSplit.VAL
+        return DatasetSplit.TEST
 
 
 @dataclasses.dataclass(slots=True)


### PR DESCRIPTION
Add a validation set. This is now a 60/20/20 train/val/test split, indicated by the `dataset` flag in the metastore.