### PR TITLE
Retrieve separate train/val/test datasets

### DIFF
--- a/usl_models/tests/flood_ml/flood_model_test.py
+++ b/usl_models/tests/flood_ml/flood_model_test.py
@@ -106,6 +106,8 @@ def test_train():
         train_dataset, val_dataset=val_dataset, epochs=epochs, steps_per_epoch=1
     )
     assert len(history.history["loss"]) == epochs
+    # Also check that the model is calculating validation metrics
+    assert "val_loss" in history.history
 
 
 def test_early_stopping():

--- a/usl_models/tests/flood_ml/flood_model_test.py
+++ b/usl_models/tests/flood_ml/flood_model_test.py
@@ -96,10 +96,15 @@ def test_train():
 
     model = flood_model.FloodModel(params, spatial_dims=(height, width))
     epochs = 2
-    dataset = mock_dataset(
+    train_dataset = mock_dataset(
         params, height=height, width=width, batch_size=batch_size, batch_count=epochs
     )
-    history = model.fit(dataset, epochs=epochs, steps_per_epoch=1)
+    val_dataset = mock_dataset(
+        params, height=height, width=width, batch_size=batch_size, batch_count=epochs
+    )
+    history = model.fit(
+        train_dataset, val_dataset=val_dataset, epochs=epochs, steps_per_epoch=1
+    )
     assert len(history.history["loss"]) == epochs
 
 
@@ -122,14 +127,27 @@ def test_early_stopping():
     epochs = 20
     model = flood_model.FloodModel(params, spatial_dims=(height, width))
 
-    dataset = mock_dataset(
+    train_dataset = mock_dataset(
         params,
         height=height,
         width=width,
         batch_size=batch_size,
         batch_count=epochs,
     )
-    history = model.fit(dataset, early_stopping=1, epochs=epochs, steps_per_epoch=1)
+    val_dataset = mock_dataset(
+        params,
+        height=height,
+        width=width,
+        batch_size=batch_size,
+        batch_count=epochs,
+    )
+    history = model.fit(
+        train_dataset,
+        val_dataset=val_dataset,
+        early_stopping=1,
+        epochs=epochs,
+        steps_per_epoch=1,
+    )
     # Check whether the model history indicates early stopping.
     assert len(history.history["loss"]) < epochs
 
@@ -142,14 +160,21 @@ def test_model_checkpoint():
 
     model = flood_model.FloodModel(params, spatial_dims=(height, width))
 
-    dataset = mock_dataset(
+    train_dataset = mock_dataset(
         params,
         height=height,
         width=width,
         batch_size=batch_size,
         batch_count=1,
     )
-    model.fit(dataset, steps_per_epoch=1)
+    val_dataset = mock_dataset(
+        params,
+        height=height,
+        width=width,
+        batch_size=batch_size,
+        batch_count=1,
+    )
+    model.fit(train_dataset, val_dataset=val_dataset, steps_per_epoch=1)
 
     with tempfile.NamedTemporaryFile(suffix=".keras") as tmp:
         model.save_model(tmp.name, overwrite=True)

--- a/usl_models/tests/flood_ml/test_dataset.py
+++ b/usl_models/tests/flood_ml/test_dataset.py
@@ -58,6 +58,7 @@ def test_load_dataset_full(mock_metastore) -> None:
     m_rainfall = 6
     ds = dataset.load_dataset(
         sim_names=["sim_name"],
+        dataset_split="train",
         batch_size=batch_size,
         n_flood_maps=5,
         m_rainfall=m_rainfall,
@@ -172,6 +173,7 @@ def test_load_dataset_windowed(mock_metastore) -> None:
     mock_storage_client.reset_mock()
     ds = dataset.load_dataset_windowed(
         sim_names=["sim_name"],
+        dataset_split="train",
         batch_size=batch_size,
         n_flood_maps=5,
         m_rainfall=m_rainfall,

--- a/usl_models/tests/integration/test_metastore_integration.py
+++ b/usl_models/tests/integration/test_metastore_integration.py
@@ -157,17 +157,27 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
     firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
         "label_chunks"
     ).document("0_0").set(
-        {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0}
+        {
+            "gcs_uri": "gs://bucket/0_0.npy",
+            "x_index": 0,
+            "y_index": 0,
+            "dataset_split": "train",
+        }
     )
 
     firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
         "label_chunks"
     ).document("0_1").set(
-        {"gcs_uri": "gs://bucket/0_1.npy", "x_index": 0, "y_index": 1}
+        {
+            "gcs_uri": "gs://bucket/0_1.npy",
+            "x_index": 0,
+            "y_index": 1,
+            "dataset_split": "train",
+        }
     )
 
     assert metastore.get_spatial_feature_and_label_chunk_metadata(
-        firestore_db, "dir%2Fsim_name"
+        firestore_db, "dir%2Fsim_name", "train"
     ) == [
         (
             {
@@ -175,7 +185,12 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
                 "x_index": 0,
                 "y_index": 0,
             },
-            {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0},
+            {
+                "gcs_uri": "gs://bucket/0_0.npy",
+                "x_index": 0,
+                "y_index": 0,
+                "dataset_split": "train",
+            },
         ),
         (
             {
@@ -183,7 +198,12 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
                 "x_index": 0,
                 "y_index": 1,
             },
-            {"gcs_uri": "gs://bucket/0_1.npy", "x_index": 0, "y_index": 1},
+            {
+                "gcs_uri": "gs://bucket/0_1.npy",
+                "x_index": 0,
+                "y_index": 1,
+                "dataset_split": "train",
+            },
         ),
     ]
 
@@ -204,26 +224,42 @@ def test_get_spatial_feature_and_label_chunk_metadata_unquoted_name(
     firestore_db.collection("study_areas").document("study_area_name").collection(
         "chunks"
     ).document("chunk_0_0").set(
-        {"feature_matrix_path": "gs://bucket/chunk_0_0.npy", "x_index": 0, "y_index": 0}
+        {
+            "feature_matrix_path": "gs://bucket/chunk_0_0.npy",
+            "x_index": 0,
+            "y_index": 0,
+            "dataset_split": "train",
+        }
     )
 
     # Insert matching labels.
     firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
         "label_chunks"
     ).document("0_0").set(
-        {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0}
+        {
+            "gcs_uri": "gs://bucket/0_0.npy",
+            "x_index": 0,
+            "y_index": 0,
+            "dataset_split": "train",
+        }
     )
 
     assert metastore.get_spatial_feature_and_label_chunk_metadata(
-        firestore_db, "dir/sim_name"
+        firestore_db, "dir/sim_name", "train"
     ) == [
         (
             {
                 "feature_matrix_path": "gs://bucket/chunk_0_0.npy",
                 "x_index": 0,
                 "y_index": 0,
+                "dataset_split": "train",
             },
-            {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0},
+            {
+                "gcs_uri": "gs://bucket/0_0.npy",
+                "x_index": 0,
+                "y_index": 0,
+                "dataset_split": "train",
+            },
         ),
     ]
 
@@ -234,7 +270,7 @@ def test_get_spatial_feature_and_label_chunk_metadata_raises_on_missing_sim(
     """Ensures we raise an error for missing simulations."""
     with pytest.raises(ValueError):
         metastore.get_spatial_feature_and_label_chunk_metadata(
-            firestore_db, "dir%2Fsim_name"
+            firestore_db, "dir%2Fsim_name", "train"
         )
 
 
@@ -259,60 +295,28 @@ def test_get_label_chunk_metadata_missing_features(firestore_db) -> None:
     firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
         "label_chunks"
     ).document("0_0").set(
-        {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0}
+        {
+            "gcs_uri": "gs://bucket/0_0.npy",
+            "x_index": 0,
+            "y_index": 0,
+            "dataset_split": "train",
+        }
     )
 
     firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
         "label_chunks"
     ).document("0_1").set(
-        {"gcs_uri": "gs://bucket/0_1.npy", "x_index": 0, "y_index": 1}
-    )
-
-    with pytest.raises(AssertionError) as excinfo:
-        metastore.get_spatial_feature_and_label_chunk_metadata(
-            firestore_db, "dir%2Fsim_name"
-        )
-
-    assert "Indices missing from labels:  Indices missing from features: (0, 1)" in str(
-        excinfo.value
-    )
-
-
-def test_get_label_chunk_metadata_missing_labels(firestore_db) -> None:
-    """Ensures we raise an error if features do not match up with labels."""
-    firestore_db.collection("simulations").document("dir%2Fsim_name").set(
         {
-            "study_area": firestore_db.collection("study_areas").document(
-                "study_area_name"
-            )
+            "gcs_uri": "gs://bucket/0_1.npy",
+            "x_index": 0,
+            "y_index": 1,
+            "dataset_split": "train",
         }
     )
 
-    # Insert 2 features.
-    firestore_db.collection("study_areas").document("study_area_name").collection(
-        "chunks"
-    ).document("chunk_0_0").set(
-        {"feature_matrix_path": "gs://bucket/chunk_0_0.npy", "x_index": 0, "y_index": 0}
-    )
-
-    firestore_db.collection("study_areas").document("study_area_name").collection(
-        "chunks"
-    ).document("chunk_0_1").set(
-        {"feature_matrix_path": "gs://bucket/chunk_0_1.npy", "x_index": 0, "y_index": 1}
-    )
-
-    # Insert 1 label.
-    firestore_db.collection("simulations").document("dir%2Fsim_name").collection(
-        "label_chunks"
-    ).document("0_0").set(
-        {"gcs_uri": "gs://bucket/0_0.npy", "x_index": 0, "y_index": 0}
-    )
-
     with pytest.raises(AssertionError) as excinfo:
         metastore.get_spatial_feature_and_label_chunk_metadata(
-            firestore_db, "dir%2Fsim_name"
+            firestore_db, "dir%2Fsim_name", "train"
         )
 
-    assert "Indices missing from labels: (0, 1) Indices missing from features:" in str(
-        excinfo.value
-    )
+    assert "Indices missing from features: (0, 1)" in str(excinfo.value)

--- a/usl_models/usl_models/flood_ml/dataset.py
+++ b/usl_models/usl_models/flood_ml/dataset.py
@@ -117,7 +117,7 @@ def load_dataset_windowed(
 
     This dataset produces the input for `model.call` and should only be used
     for training, since it uses labels.
-    For getting dat to input into `model.call_n`, use `load_dataset` instead.
+    For getting data to input into `model.call_n`, use `load_dataset` instead.
     The examples are generated from multiple simulations.
     They are windowed for training on next-map prediction.
     The dataset iteratively yields examples read from Google Cloud Storage to avoid

--- a/usl_models/usl_models/flood_ml/model.py
+++ b/usl_models/usl_models/flood_ml/model.py
@@ -130,7 +130,8 @@ class FloodModel:
 
     def fit(
         self,
-        dataset: tf.data.Dataset,
+        train_dataset: tf.data.Dataset,
+        val_dataset: tf.data.Dataset | None = None,
         epochs: int = 1,
         steps_per_epoch: int | None = None,
         early_stopping: int | None = None,
@@ -148,7 +149,11 @@ class FloodModel:
 
         # Fit the model for this sample
         return self._model.fit(
-            dataset, epochs=epochs, steps_per_epoch=steps_per_epoch, callbacks=callbacks
+            train_dataset,
+            validation_data=val_dataset,
+            epochs=epochs,
+            steps_per_epoch=steps_per_epoch,
+            callbacks=callbacks,
         )
 
     def load_model(self, filepath: str) -> None:


### PR DESCRIPTION
Updated `load_dataset` to retrieve a specific dataset split: either train, val, or test. The training script now includes a validation set.