### PR TITLE
changes to support prediction dataset

### DIFF
--- a/usl_models/tests/flood_ml/test_dataset.py
+++ b/usl_models/tests/flood_ml/test_dataset.py
@@ -18,7 +18,8 @@ def test_load_dataset_full(mock_metastore) -> None:
 
     # Set some URLs to return from our metastore functions.
     mock_metastore.get_temporal_feature_metadata.return_value = {
-        "as_vector_gcs_uri": "gs://temporal-features/temporal-feature.npy"
+        "as_vector_gcs_uri": "gs://temporal-features/temporal-feature.npy",
+        "rainfall_duration": 5,
     }
     mock_metastore.get_spatial_feature_and_label_chunk_metadata.return_value = [
         (
@@ -132,7 +133,8 @@ def test_load_dataset_windowed(mock_metastore) -> None:
 
     # Set some URLs to return from our metastore functions.
     mock_metastore.get_temporal_feature_metadata.return_value = {
-        "as_vector_gcs_uri": "gs://temporal-features/temporal-feature.npy"
+        "as_vector_gcs_uri": "gs://temporal-features/temporal-feature.npy",
+        "rainfall_duration": 5,
     }
     mock_metastore.get_spatial_feature_and_label_chunk_metadata.return_value = [
         (

--- a/usl_models/usl_models/flood_ml/dataset.py
+++ b/usl_models/usl_models/flood_ml/dataset.py
@@ -16,6 +16,36 @@ from usl_models.flood_ml import metastore
 from usl_models.flood_ml import model
 
 
+def geospatial_dataset_signature() -> tf.TensorSpec:
+    return tf.TensorSpec(
+        shape=(
+            constants.MAP_HEIGHT,
+            constants.MAP_WIDTH,
+            constants.GEO_FEATURES,
+        ),
+        dtype=tf.float32,
+    )
+
+
+def temporal_dataset_signature(m_rainfall: int) -> tf.TensorSpec:
+    return tf.TensorSpec(
+        shape=(constants.MAX_RAINFALL_DURATION, m_rainfall),
+        dtype=tf.float32,
+    )
+
+
+def spatiotemporal_dataset_signature(n_flood_maps: int) -> tf.TensorSpec:
+    return tf.TensorSpec(
+        shape=(
+            n_flood_maps,
+            constants.MAP_HEIGHT,
+            constants.MAP_WIDTH,
+            1,
+        ),
+        dtype=tf.float32,
+    )
+
+
 def load_dataset(
     sim_names: list[str],
     dataset_split: str,
@@ -68,27 +98,9 @@ def load_dataset(
         generator=generator,
         output_signature=(
             dict(
-                geospatial=tf.TensorSpec(
-                    shape=(
-                        constants.MAP_HEIGHT,
-                        constants.MAP_WIDTH,
-                        constants.GEO_FEATURES,
-                    ),
-                    dtype=tf.float32,
-                ),
-                temporal=tf.TensorSpec(
-                    shape=(constants.MAX_RAINFALL_DURATION, m_rainfall),
-                    dtype=tf.float32,
-                ),
-                spatiotemporal=tf.TensorSpec(
-                    shape=(
-                        n_flood_maps,
-                        constants.MAP_HEIGHT,
-                        constants.MAP_WIDTH,
-                        1,
-                    ),
-                    dtype=tf.float32,
-                ),
+                geospatial=geospatial_dataset_signature(),
+                temporal=temporal_dataset_signature(m_rainfall),
+                spatiotemporal=spatiotemporal_dataset_signature(n_flood_maps),
             ),
             tf.TensorSpec(
                 shape=(None, constants.MAP_HEIGHT, constants.MAP_WIDTH),

--- a/usl_models/usl_models/flood_ml/metastore.py
+++ b/usl_models/usl_models/flood_ml/metastore.py
@@ -151,11 +151,11 @@ def get_spatial_feature_and_label_chunk_metadata(
 def get_temporal_feature_metadata_for_prediction(
     db: firestore.Client, config_name: str
 ) -> dict[str, Any]:
-    """Retrieves metadata stating the location of temporal features in GCS.
+    """Retrieves metadata for temporal features in GCS.
 
     Args:
       db: The firestore client to use when retrieving metadata.
-      config_name: The name of the city cat configuration for which to retrieve metadata.
+      config_name: The name of the configuration for which to retrieve metadata.
 
     Returns:
       A dictionary with keys 'as_vector_gcs_uri' and 'rainfall_duration' which state the
@@ -165,53 +165,44 @@ def get_temporal_feature_metadata_for_prediction(
     Raises:
       ValueError: If a configuration `config_name` cannot be found.
     """
-    collection_name = "city_cat_rainfall_configs"
-    config_ref = db.collection(collection_name).document(config_name)
+    config_ref = db.collection("city_cat_rainfall_configs").document(config_name)
     config = config_ref.get()
 
     if not config.exists:
         raise ValueError(f"No such config {config_name} found.")
 
-    config_data = config.to_dict()
-   
-    return config_data
+    return config.to_dict()
 
 
 def get_spatial_feature_chunk_metadata_for_prediction(
     db: firestore.Client, study_area: str
 ) -> list[dict[str, Any]]:
-    """Retrieves metadata for chunks in the NYC study area.
+    """Retrieves metadata for chunks in the given study area.
 
     Args:
       db: The firestore client to use when retrieving metadata.
-      study_area: The name of the study_area, ex: NYC
+      study_area: The name of the study_area, e.g. NYC
 
     Returns:
-      A list of dictionaries, each representing a chunk with its metadata.
+      A list of dictionaries, each representing a chunk's metadata.
 
     Raises:
-      ValueError: If the NYC document or its chunks collection cannot be found.
+      ValueError: If the study area can not be found or it has no chunks.
     """
-    # Get the reference to the NYC document in the study_area collection
     doc_ref = db.collection("study_areas").document(study_area)
     doc = doc_ref.get()
 
     if not doc.exists:
-        raise ValueError("NYC document not found in study_area collection.")
+        raise ValueError(f"No such study area '{study_area}' found.")
 
-    # Get the chunks collection under the NYC document
-    chunks_collection = doc_ref.collection("chunks")
-    
-    # Retrieve all chunks
-    chunks = chunks_collection.stream()
-    
-    # Convert each chunk document to a dictionary and store in a list
+    chunks = doc_ref.collection("chunks").stream()
     chunk_metadata = [chunk.to_dict() for chunk in chunks]
-    
+
     if not chunk_metadata:
-        raise ValueError(f"No chunks found in the {doc_ref} document.")
+        raise ValueError(f"No chunks found in study area '{study_area}'.")
 
     return chunk_metadata
+
 
 _T = TypeVar("_T")
 

--- a/usl_models/usl_models/flood_ml/prediction_dataset.py
+++ b/usl_models/usl_models/flood_ml/prediction_dataset.py
@@ -1,0 +1,195 @@
+"""tf.data.Datasets for training FloodML model on CityCAT data."""
+
+import logging
+import random
+from typing import Iterator, Optional, Tuple
+import urllib.parse
+
+from google.cloud import firestore  # type:ignore[attr-defined]
+from google.cloud import storage  # type:ignore[attr-defined]
+import numpy
+from numpy.typing import NDArray
+import tensorflow as tf
+
+from usl_models.flood_ml import constants
+from usl_models.flood_ml import metastore
+from usl_models.flood_ml import model
+
+
+def load_prediction_dataset(
+    study_area: str,
+    city_cat_config: str, 
+    batch_size: int = 4,
+    n_flood_maps: int = constants.N_FLOOD_MAPS,
+    m_rainfall: int = constants.M_RAINFALL,
+    max_chunks: Optional[int] = None,
+    firestore_client: Optional[firestore.Client] = None,
+    storage_client: Optional[storage.Client] = None,
+) -> tf.data.Dataset:
+    """Creates a prediction dataset which generates chunks for flood model prediction.
+
+    This dataset produces the input for `model.call_n`.
+    For training with teacher-forcing, `load_dataset_windowed` should be used instead.
+    The examples are generated from multiple simulations.
+    The dataset iteratively yields examples read from Google Cloud Storage to avoid
+    pulling all examples into memory at once.
+
+    Args:
+      
+      batch_size: Size of batches yielded by the dataset. Approximate memory
+                  usage is 10GB * batch_size during training.
+      n_flood_maps: The number of flood maps in each example.
+      m_rainfall: The width of the temporal rainfall tensor.
+      max_chunks: The maximum number of examples to yield from the dataset.
+                  If `None` (default) yields all examples from the simulations.
+      firestore_client: The client to use when interacting with Firestore.
+      storage_client: The client to use when interacting with Cloud Storage.
+    """
+    firestore_client = firestore_client or firestore.Client()
+    storage_client = storage_client or storage.Client()
+
+    def generator():
+        """Generator for producing full inputs from study area"""
+        for model_input, metadata in _iter_model_inputs_for_prediction(
+        firestore_client,
+        storage_client,
+        city_cat_config,
+        study_area,
+        n_flood_maps,
+        m_rainfall,
+        max_chunks
+        ):
+            yield model_input, metadata
+
+    # Create the dataset for this simulation
+    dataset = tf.data.Dataset.from_generator(
+        generator=generator,
+        output_signature=(
+            dict(
+                geospatial=tf.TensorSpec(
+                    shape=(
+                        constants.MAP_HEIGHT,
+                        constants.MAP_WIDTH,
+                        constants.GEO_FEATURES,
+                    ),
+                    dtype=tf.float32,
+                ),
+                temporal=tf.TensorSpec(
+                    shape=(constants.MAX_RAINFALL_DURATION, m_rainfall),
+                    dtype=tf.float32,
+                ),
+                spatiotemporal=tf.TensorSpec(
+                    shape=(
+                        n_flood_maps,
+                        constants.MAP_HEIGHT,
+                        constants.MAP_WIDTH,
+                        1,
+                    ),
+                    dtype=tf.float32,
+                ),
+            ),
+            dict(
+                feature_chunk = tf.TensorSpec(shape=(), dtype=tf.string),
+                rainfall= tf.TensorSpec(shape=(), dtype=tf.int32),
+            ),
+            ),
+          )
+    # If no batch specified, do not batch the dataset, which is required
+    # for generating data for batch prediction in VertexAI.
+    if batch_size:
+        print("batch: ", batch_size)
+        dataset = dataset.batch(batch_size)
+    return dataset
+
+def _generate_temporal_tensor(
+    firestore_client: firestore.Client,
+    storage_client: storage.Client,
+    config_name: str,
+    m_rainfall: int,
+) -> tuple[tf.Tensor, str]:
+    """Creates a temporal tensor from the numpy array stored in GCS."""
+    temporal_metadata = metastore.get_temporal_feature_metadata_for_prediction(
+        firestore_client, config_name
+    )
+    gcs_url = temporal_metadata["as_vector_gcs_uri"]
+    rainfall = temporal_metadata["rainfall_duration"]
+
+    logging.info("Retrieving temporal features from %s.", gcs_url)
+
+    temporal_vector = _download_as_tensor(storage_client, gcs_url)
+    return tf.transpose(
+        tf.tile(tf.reshape(temporal_vector, (1, len(temporal_vector))), [m_rainfall, 1])
+    ), rainfall
+
+def _iter_model_inputs_for_prediction(
+    firestore_client: firestore.Client,
+    storage_client: storage.Client,
+    city_cat_config: str,
+    study_area_name: str,
+    n_flood_maps: int,
+    m_rainfall: int,
+    max_chunks: Optional[int],
+) -> Iterator[Tuple[model.Input, dict]]:
+    """Yields model inputs for each spatial chunk in the simulation."""
+    temporal, rainfall = _generate_temporal_tensor(
+        firestore_client, storage_client, city_cat_config, m_rainfall
+    )
+
+    for feature_tensor, chunk_name in _iter_study_area_tensors(
+    firestore_client, storage_client, study_area_name
+    ):
+        metadata = {
+            "feature_chunk": chunk_name,
+            "rainfall": rainfall
+        }
+
+        model_input = model.Input(
+            temporal=temporal,
+            geospatial=feature_tensor,
+            spatiotemporal=tf.zeros(
+                shape=(
+                    n_flood_maps,
+                    constants.MAP_HEIGHT,
+                    constants.MAP_WIDTH,
+                    1,
+                )
+            ),
+        )
+        yield model_input, metadata
+
+def _iter_study_area_tensors(
+    firestore_client: firestore.Client, storage_client: storage.Client, study_area_name: str
+) -> Iterator[Tuple[tf.Tensor, str]]:
+    """Yields feature tensors from chunks stored in GCS."""
+    feature_metadata = metastore.get_spatial_feature_chunk_metadata_for_prediction(
+        firestore_client, study_area_name
+    )
+
+    random.shuffle(feature_metadata)
+
+    for feature_metadata in feature_metadata:
+        feature_url = feature_metadata["feature_matrix_path"]
+        chunk_name = feature_url.split('/')[-1]
+
+        logging.info(
+            "Retrieving features from %s ", feature_url
+        )
+        feature_tensor = _download_as_tensor(storage_client, feature_url)
+        yield feature_tensor, chunk_name
+
+
+def _download_as_array(client: storage.Client, gcs_url: str) -> NDArray:
+    """Retrieves the contents at `gcs_url` from GCS as a numpy array."""
+    parsed = urllib.parse.urlparse(gcs_url)
+    bucket = client.bucket(parsed.netloc)
+    blob = bucket.blob(parsed.path.lstrip("/"))
+
+    with blob.open("rb") as fd:
+        return numpy.load(fd)
+
+def _download_as_tensor(client: storage.Client, gcs_url: str) -> tf.Tensor:
+    """Retrieves the contents at `gcs_url` from GCS as a tf tensor."""
+    return tf.convert_to_tensor(
+        _download_as_array(client, gcs_url),
+        dtype=tf.float32,
+    )

--- a/usl_models/usl_models/flood_ml/prediction_dataset.py
+++ b/usl_models/usl_models/flood_ml/prediction_dataset.py
@@ -12,13 +12,14 @@ from numpy.typing import NDArray
 import tensorflow as tf
 
 from usl_models.flood_ml import constants
+from usl_models.flood_ml import dataset
 from usl_models.flood_ml import metastore
 from usl_models.flood_ml import model
 
 
 def load_prediction_dataset(
     study_area: str,
-    city_cat_config: str, 
+    city_cat_config: str,
     batch_size: int = 4,
     n_flood_maps: int = constants.N_FLOOD_MAPS,
     m_rainfall: int = constants.M_RAINFALL,
@@ -35,7 +36,8 @@ def load_prediction_dataset(
     pulling all examples into memory at once.
 
     Args:
-      
+      study_area: The study area to build geospatial tensors for.
+      city_cat_config: The config to build a temporal tensors for.
       batch_size: Size of batches yielded by the dataset. Approximate memory
                   usage is 10GB * batch_size during training.
       n_flood_maps: The number of flood maps in each example.
@@ -49,15 +51,15 @@ def load_prediction_dataset(
     storage_client = storage_client or storage.Client()
 
     def generator():
-        """Generator for producing full inputs from study area"""
+        """Generator for producing full inputs from study area."""
         for model_input, metadata in _iter_model_inputs_for_prediction(
-        firestore_client,
-        storage_client,
-        city_cat_config,
-        study_area,
-        n_flood_maps,
-        m_rainfall,
-        max_chunks
+            firestore_client,
+            storage_client,
+            city_cat_config,
+            study_area,
+            n_flood_maps,
+            m_rainfall,
+            max_chunks,
         ):
             yield model_input, metadata
 
@@ -89,37 +91,17 @@ def load_prediction_dataset(
                 ),
             ),
             dict(
-                feature_chunk = tf.TensorSpec(shape=(), dtype=tf.string),
-                rainfall= tf.TensorSpec(shape=(), dtype=tf.int32),
+                feature_chunk=tf.TensorSpec(shape=(), dtype=tf.string),
+                rainfall=tf.TensorSpec(shape=(), dtype=tf.int32),
             ),
-            ),
-          )
+        ),
+    )
     # If no batch specified, do not batch the dataset, which is required
     # for generating data for batch prediction in VertexAI.
     if batch_size:
-        print("batch: ", batch_size)
         dataset = dataset.batch(batch_size)
     return dataset
 
-def _generate_temporal_tensor(
-    firestore_client: firestore.Client,
-    storage_client: storage.Client,
-    config_name: str,
-    m_rainfall: int,
-) -> tuple[tf.Tensor, str]:
-    """Creates a temporal tensor from the numpy array stored in GCS."""
-    temporal_metadata = metastore.get_temporal_feature_metadata_for_prediction(
-        firestore_client, config_name
-    )
-    gcs_url = temporal_metadata["as_vector_gcs_uri"]
-    rainfall = temporal_metadata["rainfall_duration"]
-
-    logging.info("Retrieving temporal features from %s.", gcs_url)
-
-    temporal_vector = _download_as_tensor(storage_client, gcs_url)
-    return tf.transpose(
-        tf.tile(tf.reshape(temporal_vector, (1, len(temporal_vector))), [m_rainfall, 1])
-    ), rainfall
 
 def _iter_model_inputs_for_prediction(
     firestore_client: firestore.Client,
@@ -131,17 +113,19 @@ def _iter_model_inputs_for_prediction(
     max_chunks: Optional[int],
 ) -> Iterator[Tuple[model.Input, dict]]:
     """Yields model inputs for each spatial chunk in the simulation."""
-    temporal, rainfall = _generate_temporal_tensor(
-        firestore_client, storage_client, city_cat_config, m_rainfall
+    temporal, rainfall = dataset._generate_temporal_tensor(
+        metastore.get_temporal_feature_metadata_for_prediction(
+            firestore_client, city_cat_config
+        ),
+        storage_client,
+        city_cat_config,
+        m_rainfall,
     )
 
     for feature_tensor, chunk_name in _iter_study_area_tensors(
-    firestore_client, storage_client, study_area_name
+        firestore_client, storage_client, study_area_name
     ):
-        metadata = {
-            "feature_chunk": chunk_name,
-            "rainfall": rainfall
-        }
+        metadata = {"feature_chunk": chunk_name, "rainfall": rainfall}
 
         model_input = model.Input(
             temporal=temporal,
@@ -157,39 +141,23 @@ def _iter_model_inputs_for_prediction(
         )
         yield model_input, metadata
 
+
 def _iter_study_area_tensors(
-    firestore_client: firestore.Client, storage_client: storage.Client, study_area_name: str
+    firestore_client: firestore.Client,
+    storage_client: storage.Client,
+    study_area_name: str,
 ) -> Iterator[Tuple[tf.Tensor, str]]:
     """Yields feature tensors from chunks stored in GCS."""
-    feature_metadata = metastore.get_spatial_feature_chunk_metadata_for_prediction(
+    all_feature_metadata = metastore.get_spatial_feature_chunk_metadata_for_prediction(
         firestore_client, study_area_name
     )
 
-    random.shuffle(feature_metadata)
+    random.shuffle(all_feature_metadata)
 
-    for feature_metadata in feature_metadata:
+    for feature_metadata in all_feature_metadata:
         feature_url = feature_metadata["feature_matrix_path"]
-        chunk_name = feature_url.split('/')[-1]
+        chunk_name = feature_url.split("/")[-1]
 
-        logging.info(
-            "Retrieving features from %s ", feature_url
-        )
-        feature_tensor = _download_as_tensor(storage_client, feature_url)
+        logging.info("Retrieving features from %s ", feature_url)
+        feature_tensor = dataset._download_as_tensor(storage_client, feature_url)
         yield feature_tensor, chunk_name
-
-
-def _download_as_array(client: storage.Client, gcs_url: str) -> NDArray:
-    """Retrieves the contents at `gcs_url` from GCS as a numpy array."""
-    parsed = urllib.parse.urlparse(gcs_url)
-    bucket = client.bucket(parsed.netloc)
-    blob = bucket.blob(parsed.path.lstrip("/"))
-
-    with blob.open("rb") as fd:
-        return numpy.load(fd)
-
-def _download_as_tensor(client: storage.Client, gcs_url: str) -> tf.Tensor:
-    """Retrieves the contents at `gcs_url` from GCS as a tf tensor."""
-    return tf.convert_to_tensor(
-        _download_as_array(client, gcs_url),
-        dtype=tf.float32,
-    )


### PR DESCRIPTION
Folks,

Please review these changes to support prediction dataset.  You should see output like this:

```study_area = "NYC"
city_cat_config = "config_v1%2FRainfall_Data_1.txt"
dataset = load_prediction_dataset(study_area=study_area, city_cat_config=city_cat_config, batch_size=1, max_chunks=1)
input_tuple = next(iter(dataset))

model_input, metadata = input_tuple

print("Model Input:")
for key, value in model_input.items():
    print(f"Key: {key}")
    print(f"Shape: {value.shape}")
    print("-" * 20)

print("Metadata:")
for key, value in metadata.items():
    if key == 'feature_chunk':
        # Convert the EagerTensor to a numpy array, then to a string
        decoded_value = value.numpy()[0].decode('utf-8')
        print(f"Key: {key}")
        print(f"Value: {decoded_value}")
    else:
        print(f"Key: {key}")
        print(f"Value: {value.numpy()}")  # Convert tensor to numpy for display
    print("-" * 20)```

