### PR TITLE
Fix incorrect field name in model dataset

### DIFF
--- a/usl_models/tests/integration/test_metastore_integration.py
+++ b/usl_models/tests/integration/test_metastore_integration.py
@@ -162,7 +162,7 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
             "gcs_uri": "gs://bucket/0_0.npy",
             "x_index": 0,
             "y_index": 0,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 
@@ -173,7 +173,7 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
             "gcs_uri": "gs://bucket/0_1.npy",
             "x_index": 0,
             "y_index": 1,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 
@@ -190,7 +190,7 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
                 "gcs_uri": "gs://bucket/0_0.npy",
                 "x_index": 0,
                 "y_index": 0,
-                "dataset_split": "train",
+                "dataset": "train",
             },
         ),
         (
@@ -203,7 +203,7 @@ def test_get_spatial_feature_and_label_chunk_metadata(firestore_db) -> None:
                 "gcs_uri": "gs://bucket/0_1.npy",
                 "x_index": 0,
                 "y_index": 1,
-                "dataset_split": "train",
+                "dataset": "train",
             },
         ),
     ]
@@ -229,7 +229,7 @@ def test_get_spatial_feature_and_label_chunk_metadata_unquoted_name(
             "feature_matrix_path": "gs://bucket/chunk_0_0.npy",
             "x_index": 0,
             "y_index": 0,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 
@@ -241,7 +241,7 @@ def test_get_spatial_feature_and_label_chunk_metadata_unquoted_name(
             "gcs_uri": "gs://bucket/0_0.npy",
             "x_index": 0,
             "y_index": 0,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 
@@ -253,13 +253,13 @@ def test_get_spatial_feature_and_label_chunk_metadata_unquoted_name(
                 "feature_matrix_path": "gs://bucket/chunk_0_0.npy",
                 "x_index": 0,
                 "y_index": 0,
-                "dataset_split": "train",
+                "dataset": "train",
             },
             {
                 "gcs_uri": "gs://bucket/0_0.npy",
                 "x_index": 0,
                 "y_index": 0,
-                "dataset_split": "train",
+                "dataset": "train",
             },
         ),
     ]
@@ -300,7 +300,7 @@ def test_get_label_chunk_metadata_missing_features(firestore_db) -> None:
             "gcs_uri": "gs://bucket/0_0.npy",
             "x_index": 0,
             "y_index": 0,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 
@@ -311,7 +311,7 @@ def test_get_label_chunk_metadata_missing_features(firestore_db) -> None:
             "gcs_uri": "gs://bucket/0_1.npy",
             "x_index": 0,
             "y_index": 1,
-            "dataset_split": "train",
+            "dataset": "train",
         }
     )
 

--- a/usl_models/usl_models/flood_ml/metastore.py
+++ b/usl_models/usl_models/flood_ml/metastore.py
@@ -120,7 +120,7 @@ def get_spatial_feature_and_label_chunk_metadata(
     label_chunks_collection = (
         _get_simulation_doc(db, sim_name)
         .collection("label_chunks")
-        .where(filter=firestore.FieldFilter("dataset_split", "==", dataset_split))
+        .where(filter=firestore.FieldFilter("dataset", "==", dataset_split))
     )
     label_metadata = [doc.to_dict() for doc in label_chunks_collection.stream()]
 


### PR DESCRIPTION
We were filtering on the wrong field name, which was causing model training to fail on empty inputs.