### PR TITLE
Avoid Scaling Files From WRF Pipeline

### DIFF
--- a/usl_pipeline/cloud_functions/main.py
+++ b/usl_pipeline/cloud_functions/main.py
@@ -129,6 +129,14 @@ def _retry_and_report_errors(
                 )
                 return
 
+            logging.info(
+                "Received event id: %s, source: %s, bucket: %s, name: %s",
+                cloud_event["id"],
+                cloud_event["source"],
+                cloud_event.data.get("bucket"),
+                cloud_event.data.get("name"),
+            )
+
             # Catch exceptions and report them with GCP error reporting.
             try:
                 func(cloud_event)
@@ -1266,6 +1274,10 @@ def rescale_feature_matrices(cloud_event: functions_framework.CloudEvent) -> Non
         cloud_event: Cloud event pointing to one of unscaled feature matrix files with
             name following the "chunk_*" pattern. Other files are ignored.
     """
+    if re.search(file_names.WPS_DOMAIN3_NC_REGEX, cloud_event.data["name"]):
+        logging.info("Skipping WRF file  %s", cloud_event.data["name"])
+        return
+
     _start_feature_rescaling_if_ready(
         storage.Client().bucket(cloud_event.data["bucket"]), cloud_event.data["name"]
     )

--- a/usl_pipeline/cloud_functions/main_test.py
+++ b/usl_pipeline/cloud_functions/main_test.py
@@ -2043,3 +2043,23 @@ def test_rescale_feature_matrices_for_wrong_file(mock_firestore_client):
     )
 
     feature_bucket.assert_not_called()
+
+
+@mock.patch.object(main.storage, "Client", autospec=True)
+@mock.patch.object(main.firestore, "Client", autospec=True)
+def test_rescale_feature_matrices_skips_wps_files(
+    mock_firestore_client, mock_storage_client
+):
+    main.rescale_feature_matrices(
+        functions_framework.CloudEvent(
+            {"source": "test", "type": "event"},
+            data={
+                "bucket": "bucket",
+                "name": "e2e_test_717_1/met_em.d03.2010-06-08_18:00:00.npy",
+                "timeCreated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            },
+        )
+    )
+
+    mock_firestore_client.assert_not_called()
+    mock_storage_client.assert_not_called()

--- a/usl_pipeline/usl_lib/usl_lib/storage/file_names.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/file_names.py
@@ -12,8 +12,8 @@ CITYCAT_BUILDINGS_TXT = "Buildings.txt"
 CITYCAT_GREEN_AREAS_TXT = "GreenAreas.txt"
 CITYCAT_SPATIAL_GREEN_AREAS_TXT = "Spatial_GreenAreas.txt"
 
-# Match only Domain 3 (500m) WPS files
-WPS_DOMAIN3_NC_REGEX = r"met_em\.d03.*\.nc$"
+# Match only Domain 3 (500m) WPS files with any file extension (e.g. .nc .npy)
+WPS_DOMAIN3_NC_REGEX = r"met_em\.d03.*\..+$"
 # Match only Domain 3 (500m) WRF files (wrfout files are not appended
 # with .nc extension)
 WRF_DOMAIN3_NC_REGEX = r"wrfout\.d03.*$"


### PR DESCRIPTION
- The rescaling logic is only implemented for flood. Skip WRF files triggering the function.
- Log file names we see from the cloud function decorator.