### PR TITLE
[WRF] Relax regex for WPS and WRF filenames

### DIFF
--- a/usl_pipeline/usl_lib/usl_lib/storage/file_names.py
+++ b/usl_pipeline/usl_lib/usl_lib/storage/file_names.py
@@ -15,7 +15,7 @@ CITYCAT_SPATIAL_GREEN_AREAS_TXT = "Spatial_GreenAreas.txt"
 # Heat config files with any file extension (e.g. .txt .ini)
 HEAT_CONFIG_TXT_REGEX = r"Heat\_Data\_.*\..+$"
 # Match only Domain 3 (500m) WPS files with any file extension (e.g. .nc .npy)
-WPS_DOMAIN3_NC_REGEX = r"met_em\.d03.*\..+$"
+WPS_DOMAIN3_NC_REGEX = r"met_em.*d03.*\..+$"
 # Match only Domain 3 (500m) WRF files (wrfout files are not appended
 # with .nc extension)
-WRF_DOMAIN3_NC_REGEX = r"wrfout\.d03.*$"
+WRF_DOMAIN3_NC_REGEX = r"wrfout.*d03.*$"


### PR DESCRIPTION
Filenames may sometimes use `_` and other times `.` - example:
met_em.d03.2010-05-22_00:00:00.nc
wrfout_d03_2015-06-25_15:00:00

Relax regex for both cases to handle both.