### PR TITLE
I have added the dataset file/testing, and integration into the model

### DIFF
--- a/usl_models/tests/atmo_ml/dataset_test.py
+++ b/usl_models/tests/atmo_ml/dataset_test.py
@@ -1,0 +1,91 @@
+import tensorflow as tf
+from usl_models.atmo_ml import dataset, constants
+
+
+def test_process_dataset():
+    """Test to ensure proper input-output sequence generation."""
+    # Create fake inputs for the dataset (Spatial, Spatiotemporal, LU Index, Labels)
+    batch_size = 4
+    height = constants.MAP_HEIGHT
+    width = constants.MAP_WIDTH
+    spatial_features = constants.num_spatial_features
+    spatiotemporal_features = constants.num_spatiotemporal_features
+    time_steps = constants.INPUT_TIME_STEPS
+    output_channels = constants.OUTPUT_CHANNELS
+
+    # Simulating fake inputs (spatial, spatiotemporal, lu_index) and labels
+    spatial_input = tf.random.normal((batch_size, height, width, spatial_features))
+    spatiotemporal_input = tf.random.normal(
+        (batch_size, time_steps, height, width, spatiotemporal_features)
+    )
+    lu_index_input = tf.random.uniform(
+        (batch_size, height, width),
+        minval=0,
+        maxval=constants.lu_index_vocab_size,
+        dtype=tf.int32,
+    )
+    labels = tf.random.normal(
+        (batch_size, constants.OUTPUT_TIME_STEPS, height, width, output_channels)
+    )
+
+    # Creating inputs as dictionary similar to model input
+    inputs = {
+        "spatial": spatial_input,
+        "spatiotemporal": spatiotemporal_input,
+        "lu_index": lu_index_input,
+    }
+
+    # Create a fake dataset
+    train_dataset = tf.data.Dataset.from_tensor_slices((inputs, labels)).batch(
+        batch_size
+    )
+
+    # Process the dataset
+    processed_train_dataset = dataset.process_dataset(train_dataset)
+
+    # Fetch one batch to check its structure
+    for batch in processed_train_dataset.take(1):
+        processed_inputs, processed_labels = batch
+
+        # Assert input-output shapes
+        assert "spatial" in processed_inputs
+        assert "spatiotemporal" in processed_inputs
+        assert "lu_index" in processed_inputs
+
+        # Expected shapes
+        expected_spatial_shape = (
+            batch_size,
+            height,
+            width,
+            spatial_features + constants.embedding_dim,
+        )
+        assert processed_inputs["spatial"].shape == expected_spatial_shape, (
+            f"Expected spatial shape {expected_spatial_shape} but got "
+            f"{processed_inputs['spatial'].shape}"
+        )
+
+        expected_spatiotemporal_shape = (
+            batch_size,
+            time_steps,
+            height,
+            width,
+            spatiotemporal_features,
+        )
+        assert (
+            processed_inputs["spatiotemporal"].shape == expected_spatiotemporal_shape
+        ), (
+            f"Expected spatiotemporal shape {expected_spatiotemporal_shape} but got "
+            f"{processed_inputs['spatiotemporal'].shape}"
+        )
+
+        expected_output_shape = (
+            batch_size,
+            constants.OUTPUT_TIME_STEPS,
+            height,
+            width,
+            output_channels,
+        )
+        assert processed_labels.shape == expected_output_shape, (
+            f"Expected output shape {expected_output_shape} but got "
+            f"{processed_labels.shape}"
+        )

--- a/usl_models/usl_models/atmo_ml/dataset.py
+++ b/usl_models/usl_models/atmo_ml/dataset.py
@@ -1,0 +1,77 @@
+"""Dataset processing for AtmoML model."""
+
+import tensorflow as tf
+from usl_models.atmo_ml import constants
+from usl_models.atmo_ml import input_output_sequences
+
+
+def process_dataset(dataset: tf.data.Dataset) -> tf.data.Dataset:
+    """Processes the dataset and generates input/output sequences."""
+    processed_data = []
+
+    for data in dataset:
+        inputs, labels = data
+
+        # Extract individual components from inputs
+        spatial_input = inputs["spatial"]
+        spatiotemporal_input = inputs["spatiotemporal"]
+        lu_index_input = inputs["lu_index"]
+
+        # Process the sequence
+        sequence_generator = input_output_sequences.create_input_output_sequences(
+            spatiotemporal_input, labels
+        )
+
+        # Append the processed inputs (as a dictionary) and output sequences
+        for input_sequence, output_sequence in sequence_generator:
+            processed_data.append(
+                (
+                    {
+                        "spatial": spatial_input,
+                        "spatiotemporal": input_sequence,
+                        "lu_index": lu_index_input,
+                    },
+                    output_sequence,
+                )
+            )
+
+    return tf.data.Dataset.from_generator(
+        lambda: iter(processed_data),
+        output_signature=(
+            {
+                "spatial": tf.TensorSpec(
+                    shape=(
+                        None,
+                        constants.MAP_HEIGHT,
+                        constants.MAP_WIDTH,
+                        constants.num_spatial_features,
+                    ),
+                    dtype=tf.float32,
+                ),
+                "spatiotemporal": tf.TensorSpec(
+                    shape=(
+                        None,
+                        constants.INPUT_TIME_STEPS,
+                        constants.MAP_HEIGHT,
+                        constants.MAP_WIDTH,
+                        constants.num_spatiotemporal_features,
+                    ),
+                    dtype=tf.float32,
+                ),
+                "lu_index": tf.TensorSpec(
+                    shape=(None, constants.MAP_HEIGHT, constants.MAP_WIDTH),
+                    dtype=tf.int32,
+                ),
+            },
+            tf.TensorSpec(
+                shape=(
+                    None,
+                    constants.OUTPUT_TIME_STEPS,
+                    constants.MAP_HEIGHT,
+                    constants.MAP_WIDTH,
+                    constants.OUTPUT_CHANNELS,
+                ),
+                dtype=tf.float32,
+            ),
+        ),
+    )

--- a/usl_models/usl_models/atmo_ml/model.py
+++ b/usl_models/usl_models/atmo_ml/model.py
@@ -9,6 +9,7 @@ from keras.layers import Embedding
 from usl_models.atmo_ml import constants
 from usl_models.atmo_ml import data_utils
 from usl_models.atmo_ml import model_params
+from usl_models.atmo_ml import dataset
 
 AtmoModelParams: TypeAlias = model_params.AtmoModelParams
 
@@ -114,6 +115,12 @@ class AtmoModel:
         callbacks: List[Callable] | None = None,
     ):
         """Fit the model to the given dataset."""
+        # Process datasets using the process_dataset function
+        processed_train_dataset = dataset.process_dataset(train_dataset)
+        processed_val_dataset = (
+            dataset.process_dataset(val_dataset) if val_dataset else None
+        )
+
         if callbacks is None:
             callbacks = []
         if early_stopping is not None:
@@ -124,8 +131,8 @@ class AtmoModel:
             )
 
         return self._model.fit(
-            train_dataset,
-            validation_data=val_dataset,
+            processed_train_dataset,
+            validation_data=processed_val_dataset,
             epochs=epochs,
             steps_per_epoch=steps_per_epoch,
             callbacks=callbacks,


### PR DESCRIPTION
@Katsutoshii THE DATASET & dataset_test are working, however calling the model does not work (pytest atmo_model_test.py).
Running into the issue:
                                break

                logs = tf_utils.sync_to_numpy_or_python_type(logs)
                if logs is None:
>                   raise ValueError(
                        "Unexpected result of `train_function` "
                        "(Empty logs). This could be due to issues in input "
                        "pipeline that resulted in an empty dataset. "
                        "Otherwise, please use "
                        "`Model.compile(..., run_eagerly=True)`, or "
                        "`tf.config.run_functions_eagerly(True)` for more "
                        "information of where went wrong, or file a "
                        "issue/bug to `tf.keras`."
                    )
E                   ValueError: Unexpected result of `train_function` (Empty logs). This could be due to issues in input pipeline that resulted in an empty dataset. Otherwise, please use `Model.compile(..., run_eagerly=True)`, or `tf.config.run_functions_eagerly(True)` for more information of where went wrong, or file a issue/bug to `tf.keras`.

../../.venv/lib/python3.11/site-packages/keras/src/engine/training.py:1819: ValueError
----------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------Epoch 1/2
----------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------2024-09-17 12:26:51.326888: E tensorflow/core/grappler/optimizers/meta_optimizer.cc:961] layout failed: INVALID_ARGUMENT: Size of values 0 does not match size of permutation 4 @ fanin shape inatmo_conv_lstm_6/conv_lstm/conv_lstm2d_6/while/body/_1/atmo_conv_lstm_6/conv_lstm/conv_lstm2d_6/while/dropout_7/SelectV2-2-TransposeNHWCToNCHW-LayoutOptimizer
------------------------------------------------------------------------------------ Captured log call -------------------------------------------------------------------------------------WARNING  tensorflow:data_adapter.py:1390 Your input ran out of data; interrupting training. Make sure that your dataset or generator can generate at least `steps_per_epoch * epochs` batches (in this case, 2 batches). You may need to use the repeat() function when building your dataset.
===================================================================================== warnings summary =====================================================================================tests/atmo_ml/atmo_model_test.py: 57 warnings
  /usr/lib/python3.11/random.py:362: DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
    return self.randrange(a, b+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= short test summary info ==================================================================================FAILED atmo_model_test.py::test_train - ValueError: in user code:
FAILED atmo_model_test.py::test_early_stopping - ValueError: in user code:
FAILED atmo_model_test.py::test_model_checkpoint - ValueError: in user code:
FAILED atmo_model_test.py::test_model_with_processed_data - ValueError: Unexpected result of `train_function` (Empty logs). This could be due to issues in input pipeline that resulted in an empty dataset. Otherwise, please use `Model.compile(....